### PR TITLE
gitk: windows: make "Auto-select" copy to clipboard

### DIFF
--- a/gitk
+++ b/gitk
@@ -11594,13 +11594,16 @@ proc prefspage_general {notebook} {
     ${NS}::checkbutton $page.showlocal -text [mc "Show local changes"] \
         -variable showlocalchanges
     grid x $page.showlocal -sticky w
-    ${NS}::checkbutton $page.autoselect -text [mc "Auto-select commit ID (length)"] \
-        -variable autoselect
-    spinbox $page.autosellen -from 1 -to 40 -width 4 -textvariable autosellen
-    grid x $page.autoselect $page.autosellen -sticky w
     ${NS}::checkbutton $page.hideremotes -text [mc "Hide remote refs"] \
         -variable hideremotes
     grid x $page.hideremotes -sticky w
+
+    ${NS}::checkbutton $page.autoselect -text [mc "Copy commit ID to X11 selection"] \
+        -variable autoselect
+    grid x $page.autoselect -sticky w
+    spinbox $page.autosellen -from 1 -to 40 -width 4 -textvariable autosellen
+    ${NS}::label $page.autosellenl -text [mc "Length of commit ID to copy"]
+    grid x $page.autosellenl $page.autosellen -sticky w
 
     ${NS}::label $page.ddisp -text [mc "Diff display options"]
     grid $page.ddisp - -sticky w -pady 10

--- a/gitk
+++ b/gitk
@@ -2223,7 +2223,7 @@ proc makewindow {} {
     set sha1entry .tf.bar.sha1
     set entries $sha1entry
     set sha1but .tf.bar.sha1label
-    button $sha1but -text "[mc "SHA1 ID:"] " -state disabled -relief flat \
+    button $sha1but -text "[mc "Commit ID:"] " -state disabled -relief flat \
         -command gotocommit -width 8
     $sha1but conf -disabledforeground [$sha1but cget -foreground]
     pack .tf.bar.sha1label -side left
@@ -8756,7 +8756,7 @@ proc sha1change {n1 n2 op} {
     if {$state == "normal"} {
         $sha1but conf -state normal -relief raised -text "[mc "Goto:"] "
     } else {
-        $sha1but conf -state disabled -relief flat -text "[mc "SHA1 ID:"] "
+        $sha1but conf -state disabled -relief flat -text "[mc "Commit ID:"] "
     }
 }
 
@@ -8775,7 +8775,7 @@ proc gotocommit {} {
             set matches [longid $id]
             if {$matches ne {}} {
                 if {[llength $matches] > 1} {
-                    error_popup [mc "Short SHA1 id %s is ambiguous" $id]
+                    error_popup [mc "Short commit ID %s is ambiguous" $id]
                     return
                 }
                 set id [lindex $matches 0]
@@ -8792,7 +8792,7 @@ proc gotocommit {} {
         return
     }
     if {[regexp {^[0-9a-fA-F]{4,}$} $sha1string]} {
-        set msg [mc "SHA1 id %s is not known" $sha1string]
+        set msg [mc "Commit ID %s is not known" $sha1string]
     } else {
         set msg [mc "Revision %s is not in the current view" $sha1string]
     }
@@ -11594,7 +11594,7 @@ proc prefspage_general {notebook} {
     ${NS}::checkbutton $page.showlocal -text [mc "Show local changes"] \
         -variable showlocalchanges
     grid x $page.showlocal -sticky w
-    ${NS}::checkbutton $page.autoselect -text [mc "Auto-select SHA1 (length)"] \
+    ${NS}::checkbutton $page.autoselect -text [mc "Auto-select commit ID (length)"] \
         -variable autoselect
     spinbox $page.autosellen -from 1 -to 40 -width 4 -textvariable autosellen
     grid x $page.autoselect $page.autosellen -sticky w

--- a/gitk
+++ b/gitk
@@ -7344,7 +7344,7 @@ proc selectline {l isnew {desired_loc {}} {switch_to_patch 0}} {
     global mergemax numcommits pending_select
     global cmitmode showneartags allcommits
     global targetrow targetid lastscrollrows
-    global autoselect autosellen jump_to_here
+    global autocopy autoselect autosellen jump_to_here
     global vinlinediff
 
     unset -nocomplain pending_select
@@ -7412,6 +7412,10 @@ proc selectline {l isnew {desired_loc {}} {switch_to_patch 0}} {
     $sha1entry insert 0 $id
     if {$autoselect} {
         $sha1entry selection range 0 $autosellen
+    }
+    if {$autocopy} {
+        clipboard clear
+        clipboard append [string range $id 0 [expr $autosellen - 1]]
     }
     rhighlight_sel $id
 
@@ -11576,7 +11580,7 @@ proc create_prefs_page {w} {
 
 proc prefspage_general {notebook} {
     global NS maxwidth maxgraphpct showneartags showlocalchanges
-    global tabstop limitdiffs autoselect autosellen extdifftool perfile_attrs
+    global tabstop limitdiffs autocopy autoselect autosellen extdifftool perfile_attrs
     global hideremotes want_ttk have_ttk maxrefs web_browser
 
     set page [create_prefs_page $notebook.general]
@@ -11598,6 +11602,9 @@ proc prefspage_general {notebook} {
         -variable hideremotes
     grid x $page.hideremotes -sticky w
 
+    ${NS}::checkbutton $page.autocopy -text [mc "Copy commit ID to clipboard"] \
+        -variable autocopy
+    grid x $page.autocopy -sticky w
     ${NS}::checkbutton $page.autoselect -text [mc "Copy commit ID to X11 selection"] \
         -variable autoselect
     grid x $page.autoselect -sticky w
@@ -12403,6 +12410,7 @@ set maxlinelen 200
 set showlocalchanges 1
 set limitdiffs 1
 set datetimeformat "%Y-%m-%d %H:%M:%S"
+set autocopy 0
 set autoselect 1
 set autosellen 40
 set perfile_attrs 0
@@ -12500,7 +12508,7 @@ config_check_tmp_exists 50
 
 set config_variables {
     mainfont textfont uifont tabstop findmergefiles maxgraphpct maxwidth
-    cmitmode wrapcomment autoselect autosellen showneartags maxrefs visiblerefs
+    cmitmode wrapcomment autocopy autoselect autosellen showneartags maxrefs visiblerefs
     hideremotes showlocalchanges datetimeformat limitdiffs uicolor want_ttk
     bgcolor fgcolor uifgcolor uifgdisabledcolor colors diffcolors mergecolors
     markbgcolor diffcontext selectbgcolor foundbgcolor currentsearchhitbgcolor


### PR DESCRIPTION
The config option "Auto-select SHA1 (length)" (widget-text-)selects the first $autosellen chars of the commit hash. However, selection on its own is arguably not very useful, and also not necessarily visible when not focused, e.g. with Windows native theme (the default, but is visible on Windows with other themes, like "clam").

The real goal here to copy the text to the [selection?] clipboard, which works on X11 where "selection" is synonymous with "clipboard selection", but not necessariy elsewhere, for instance on Windows (where selecting the text doesn't copy it), and maybe elsewhere too.

This commit adds explicit copy to clipboard on Windows, which happens whenever the user clicks a commit-graph entry, and like X11, affected by the configured length and enable/disable checkbox.

Possible future modifications:
- Fix other platforms if needed, e.g. maybe non-X11 macOS Tk, Wayland.
- Rename Auto-select to Auto-copy (at least at the config dialog).
- Rename SHA1 to "commit hash" (I think git plans a move to SHA256).
- Ensure "foo bar" Auto-select length is rejected at the dialog (probably also at other numeric input fields).