### PR TITLE
gitk: respect foundbgcolor variable in the top panel

### DIFF
--- a/gitk
+++ b/gitk
@@ -7139,7 +7139,7 @@ proc findselectline {l} {
 
 # mark the bits of a headline or author that match a find string
 proc markmatches {canv l str tag matches font row} {
-    global selectedline
+    global selectedline foundbgcolor
 
     set bbox [$canv bbox $tag]
     set x0 [lindex $bbox 0]
@@ -7153,7 +7153,7 @@ proc markmatches {canv l str tag matches font row} {
         set xlen [font measure $font [string range $str 0 [expr {$end}]]]
         set t [$canv create rect [expr {$x0+$xoff}] $y0 \
                    [expr {$x0+$xlen+2}] $y1 \
-                   -outline {} -tags [list match$l matches] -fill yellow]
+                   -outline {} -tags [list match$l matches] -fill $foundbgcolor]
         $canv lower $t
         if {$row == $selectedline} {
             $canv raise $t secsel


### PR DESCRIPTION
This fixes the top panel always using yellow as highlight color for search result matches, regardless of foundbgcolor value.

Here's a quick preview of the fix; `foundbgcolor` is set to magenta for visibility:

| Before | After |
| --- | --- |
| ![gitk-before](https://github.com/user-attachments/assets/450fd1dd-a8cd-455c-94f5-1c8d72e3789c) | ![gitk-after](https://github.com/user-attachments/assets/ccead7c3-5e3d-4150-98dc-46c7be7a8ad6) |

Please let me know if anything in this pull needs to be changed.