### PR TITLE
(Bug with POC workaround) use pbcopy on MacOS for better clipboard manager support

### DIFF
--- a/gitk
+++ b/gitk
@@ -113,6 +113,33 @@ if {[is_Windows]} {
 
 # End of safe PATH lookup stuff
 
+proc have_pbcopy {} {
+    if {$::tcl_platform(os) ne {Darwin}} {
+        return 0
+    }
+    if {[catch { exec -ignorestderr -- pbcopy -help 2>@1 } helptext] != 0 } {
+        return 0
+    }
+    if {![string match "*Usage: pbcopy*" $helptext]} {
+        return 0
+    }
+    return 1
+}
+
+if {[have_pbcopy]} {
+    proc set_clipboard {text} {
+        # Using `pbcopy` works around
+        # https://core.tcl-lang.org/tk/tktview/e94c8bc845b4d5a658cd5421ef23ef2484560fa8
+        # `clipboard append` trims the last newline, so we do too.
+        exec pbcopy << [string trimright $text "\n"]
+    }
+} else {
+    proc set_clipboard {text} {
+        clipboard clear
+        clipboard append -- $text
+    }
+}
+
 # Wrap exec/open to sanitize arguments
 
 # unsafe arguments begin with redirections or the pipe or background operators
@@ -2886,7 +2913,7 @@ proc makewindow {} {
         {mc "Check out this branch" command cobranch}
         {mc "Rename this branch" command mvbranch}
         {mc "Remove this branch" command rmbranch}
-        {mc "Copy branch name" command {clipboard clear; clipboard append $headmenuhead}}
+        {mc "Copy branch name" command {set_clipboard $headmenuhead}}
     }
     $headctxmenu configure -tearoff 0
 
@@ -2897,7 +2924,7 @@ proc makewindow {} {
         {mc "Highlight this only" command {flist_hl 1}}
         {mc "External diff" command {external_diff}}
         {mc "Blame parent commit" command {external_blame 1}}
-        {mc "Copy path" command {clipboard clear; clipboard append $flist_menu_file}}
+        {mc "Copy path" command {set_clipboard $flist_menu_file}}
     }
     $flist_menu configure -tearoff 0
 
@@ -7597,8 +7624,7 @@ proc selectline {l isnew {desired_loc {}} {switch_to_patch 0}} {
         $sha1entry selection range 0 $autosellen
     }
     if {$autocopy} {
-        clipboard clear
-        clipboard append [string range $id 0 [expr $autosellen - 1]]
+        set_clipboard [string range $id 0 [expr $autosellen - 1]]
     }
     rhighlight_sel $id
 
@@ -9660,8 +9686,7 @@ proc copyreference {} {
     }
     set reference [safe_exec [concat $cmd $rowmenuid]]
 
-    clipboard clear
-    clipboard append $reference
+    set_clipboard $reference
 }
 
 proc writecommit {} {


### PR DESCRIPTION
This could be considered as a bug report with a proof of concept for a workaround.

**TLDR:** on Mac OS, gitk's "copy commit reference" and other clipboard operations are not detected properly by clipboard managers due to a Tk bug. The *first* copy from gitk is often detected, but any further ones are not.

See the links below for more details.

The POC fix is simply to shell out to Mac OS's `pbcopy` instead of using Tk's `clipboard append` on Mac OS. If the Tk bug could be fixed, that would probably be better.

I am not sure whether this is ready to merge. In particular, I am not familiar with Tcl/Tk conventions and I have only tested this on Tk 8.6.16. 

--------------

On Mac OS, current versions of Tk 9 or Tk 8 `clipboard append` do not interact properly with clipboard managers. This makes `gitk` interact badly with them as well. See [1] for an example of how this affects `gitk` and [2] for a ticket describing the problem with Tk.

This commit works around the problem by having `gitk` use the `pbcopy` CLI to copy to the clipboard instead of Tk's `clipboard append`, as long as we are on Mac OS and `pbcopy` is available. AFAIK, `pbcopy` is always installed with Mac OS.

[1]: https://github.com/p0deje/Maccy/issues/1100
[2]: https://core.tcl-lang.org/tk/tktview/e94c8bc845b4d5a658cd5421ef23ef2484560fa8

1: <https://github.com/p0deje/Maccy/issues/1100>
2: <https://core.tcl-lang.org/tk/tktview/e94c8bc845b4d5a658cd5421ef23ef2484560fa8>