### PR TITLE
Updates for Tcl/Tk 9.0 support, depends upon PR #22

### DIFF
--- a/gitk
+++ b/gitk
@@ -7,7 +7,7 @@ exec wish "$0" -- "$@"
 # and distributed under the terms of the GNU General Public Licence,
 # either version 2, or (at your option) any later version.
 
-if {[catch {package require Tcl 8.6-8.8} err]} {
+if {[catch {package require Tcl 8.6-} err]} {
     catch {wm withdraw .}
     tk_messageBox \
         -icon error \


### PR DESCRIPTION
I've been working on tcl 8.6 / 9.0 updates for a while, have read the proposed patches from @qykth-git and I believe these miss some important things, it is easier for me to just show my work including explanations in the commit messages. Key differences:

There are a number of updates to mouse scroll handling we should make for Tcl/Tk 8.6, these depend upon TIP 171, and this precedes anything for TIP 474 / Tcl 9. We should update gitk requirements to be 8.6 before doing this as 8.4/8.5 don't support TIP 171, 8.6 will likely continue in use for a decade as 9.0 just hit. My 9.0 mouse version uses the Option- modifier to select large motion (like on x11 previously) vs fine motion (line on aqua previously), similar to how Tk changes this by default on other widgets.

Tcl 9 includes TIP 699 because of much confusion about binary channels. Following that document and looking carefully at gikt, I reach a different result than 042ede8, reasoning is in the 0f4b70cc2d commit message.

There are additional changes using -profile needed to operate on Tcl 9 to cover some encoding issues, 5d5d337bda and 036fc90675.

I'm successfully using gitk (and git-gui) on Tcl8.6 and on Tcl9.0.1 with this set (no longer have 8.7, but did some of the earlier work with that).   