### PR TITLE
gitk: add an option to sort by ref type on the 'tags and heads' view

### DIFF
--- a/gitk
+++ b/gitk
@@ -10332,7 +10332,7 @@ proc refill_reflist {} {
         if {![string match "remotes/*" $n] && [string match $reflistfilter $n]} {
             if {[commitinview $headids($n) $curview]} {
                 lappend localrefs [list $n H]
-                if {[info exists upstreamofref($n)]} {
+                if {[info exists upstreamofref($n)] && [commitinview $headids($upstreamofref($n)) $curview]} {
                     lappend trackedremoterefs [list $upstreamofref($n) R]
                 }
             } else {

--- a/gitk
+++ b/gitk
@@ -10340,7 +10340,7 @@ proc refill_reflist {} {
             }
         }
     }
-    set trackedremoterefs [lsort -index 0 $trackedremoterefs]
+    set trackedremoterefs [lsort -index 0 -unique $trackedremoterefs]
     set localrefs [lsort -index 0 $localrefs]
 
     foreach n [array names headids] {


### PR DESCRIPTION
In the "Tags and heads" view, the list of refs is globally sorted. The list of local refs (heads) is separated by the remote refs.  This change re-orders the view to be: local refs, remote refs tracked by local refs, remote refs, tags, and then other refs

A configuration option is added to enable or disable this behavior.

--

Several of my co-workers and I have been using this patch for several years.  Without this patch, the Tags and Heads view has a giant split in the middle of the local branches at "r" (where "remotes/" lives).

Contrast the views with the git source with three local branches, "master", "prefetch", and "sorting".
With **sort by ref** disabled:
<img width="302" height="312" alt="image" src="https://github.com/user-attachments/assets/68c4be0c-3881-44b8-9763-05e5eb96afd3" />
With **sort by ref** enabled:
<img width="316" height="326" alt="image" src="https://github.com/user-attachments/assets/ef899d2b-e49f-44c8-bd5d-ac4f8ca0189c" />

In my opinion, this allows the branches most relevant to the user to be sorted to the top.