### PR TITLE
gitk i18n: Update Bulgarian translation (322t)

### DIFF
--- a/po/bg.po
+++ b/po/bg.po
@@ -18,77 +18,58 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: git-gui.sh:819
 #, tcl-format
 msgid "Invalid font specified in %s:"
 msgstr "Указан е неправилен шрифт в „%s“:"
 
-#: git-gui.sh:873
 msgid "Main Font"
 msgstr "Основен шрифт"
 
-#: git-gui.sh:874
 msgid "Diff/Console Font"
 msgstr "Шрифт за разликите/конзолата"
 
-#: git-gui.sh:889 git-gui.sh:905 git-gui.sh:919 git-gui.sh:948 git-gui.sh:964
-#: git-gui.sh:3061
 msgid "git-gui: fatal error"
 msgstr "git-gui: фатална грешка"
 
-#: git-gui.sh:890
 msgid "Cannot find git in PATH."
 msgstr "Командата git липсва в пътя (PATH)."
 
-#: git-gui.sh:920
 msgid "Cannot parse Git version string:"
 msgstr "Низът с версията на Git не може да се анализира:"
 
-#: git-gui.sh:941
 msgid "Insufficient git version, require: "
 msgstr "Прекалено ниска версия на git, необходима е поне: "
 
-#: git-gui.sh:942
 msgid "git returned:"
 msgstr "git върна:"
 
-#: git-gui.sh:1164
 msgid "Git directory not found:"
 msgstr "Директорията на Git не е открита:"
 
-#: git-gui.sh:1181
 msgid "Cannot move to top of working directory:"
 msgstr "Не може да се премине към родителската директория."
 
-#: git-gui.sh:1189
 msgid "Cannot use bare repository:"
 msgstr "Голо хранилище не може да се използва:"
 
-#: git-gui.sh:1197
 msgid "No working directory"
 msgstr "Работната директория липсва"
 
-#: git-gui.sh:1371 lib/checkout_op.tcl:306
 msgid "Refreshing file status..."
 msgstr "Обновяване на състоянието на файла…"
 
-#: git-gui.sh:1404
 msgid "Scanning for modified files ..."
 msgstr "Проверка за променени файлове…"
 
-#: git-gui.sh:1484
 msgid "Calling prepare-commit-msg hook..."
 msgstr "Куката „prepare-commit-msg“ се изпълнява в момента…"
 
-#: git-gui.sh:1501
 msgid "Commit declined by prepare-commit-msg hook."
 msgstr "Подаването е отхвърлено от куката „prepare-commit-msg“."
 
-#: git-gui.sh:1659 lib/browser.tcl:250
 msgid "Ready."
 msgstr "Готово."
 
-#: git-gui.sh:1822
 #, tcl-format
 msgid ""
 "Display limit (gui.maxfilesdisplayed = %s) reached, not showing all %s files."
@@ -97,721 +78,539 @@ msgstr ""
 "извеждане(gui.maxfilesdisplayed = %s), съответно не са показани всички %s "
 "файла."
 
-#: git-gui.sh:1945
 msgid "Unmodified"
 msgstr "Непроменен"
 
-#: git-gui.sh:1947
 msgid "Modified, not staged"
 msgstr "Променен, но не е в индекса"
 
-#: git-gui.sh:1948 git-gui.sh:1960
 msgid "Staged for commit"
 msgstr "В индекса за подаване"
 
-#: git-gui.sh:1949 git-gui.sh:1961
 msgid "Portions staged for commit"
 msgstr "Части са в индекса за подаване"
 
-#: git-gui.sh:1950 git-gui.sh:1962
 msgid "Staged for commit, missing"
 msgstr "В индекса за подаване, но липсва"
 
-#: git-gui.sh:1952
 msgid "File type changed, not staged"
 msgstr "Видът на файла е сменен, но не е в индекса"
 
-#: git-gui.sh:1953 git-gui.sh:1954
 msgid "File type changed, old type staged for commit"
 msgstr "Видът на файла е сменен, но новият вид не е в индекса"
 
-#: git-gui.sh:1955
 msgid "File type changed, staged"
 msgstr "Видът на файла е сменен и е в индекса"
 
-#: git-gui.sh:1956
 msgid "File type change staged, modification not staged"
 msgstr "Видът на файла е сменен в индекса, но не и съдържанието"
 
-#: git-gui.sh:1957
 msgid "File type change staged, file missing"
 msgstr "Видът на файла е сменен в индекса, но файлът липсва"
 
-#: git-gui.sh:1959
 msgid "Untracked, not staged"
 msgstr "Неследен"
 
-#: git-gui.sh:1964
 msgid "Missing"
 msgstr "Липсващ"
 
-#: git-gui.sh:1965
 msgid "Staged for removal"
 msgstr "В индекса за изтриване"
 
-#: git-gui.sh:1966
 msgid "Staged for removal, still present"
 msgstr "В индекса за изтриване, но още го има"
 
-#: git-gui.sh:1968 git-gui.sh:1969 git-gui.sh:1970 git-gui.sh:1971
-#: git-gui.sh:1972 git-gui.sh:1973
 msgid "Requires merge resolution"
 msgstr "Изисква коригиране при сливане"
 
-#: git-gui.sh:2018
 msgid "Couldn't find gitk in PATH"
 msgstr "Командата „gitk“ липсва в пътищата, определени от променливата PATH."
 
-#: git-gui.sh:2065 git-gui.sh:2101
 #, tcl-format
 msgid "Starting %s... please wait..."
 msgstr "Стартиране на „%s“…, изчакайте…"
 
-#: git-gui.sh:2080
 msgid "Couldn't find git gui in PATH"
 msgstr ""
 "Командата „git gui“ липсва в пътищата, определени от променливата PATH."
 
-#: git-gui.sh:2580 lib/choose_repository.tcl:43
 msgid "Repository"
 msgstr "Хранилище"
 
-#: git-gui.sh:2581
 msgid "Edit"
 msgstr "Редактиране"
 
-#: git-gui.sh:2583 lib/choose_rev.tcl:557
 msgid "Branch"
 msgstr "Клон"
 
-#: git-gui.sh:2586 lib/choose_rev.tcl:544
 msgid "Commit@@noun"
 msgstr "Подаване"
 
-#: git-gui.sh:2589 lib/merge.tcl:118 lib/merge.tcl:165
 msgid "Merge"
 msgstr "Сливане"
 
-#: git-gui.sh:2590 lib/choose_rev.tcl:553
 msgid "Remote"
 msgstr "Отдалечено хранилище"
 
-#: git-gui.sh:2593
 msgid "Tools"
 msgstr "Команди"
 
-#: git-gui.sh:2602
 msgid "Explore Working Copy"
 msgstr "Разглеждане на работното копие"
 
-#: git-gui.sh:2615
 msgid "Git Bash"
 msgstr "Bash за Git"
 
-#: git-gui.sh:2625
 msgid "Browse Current Branch's Files"
 msgstr "Разглеждане на файловете в текущия клон"
 
-#: git-gui.sh:2629
 msgid "Browse Branch Files..."
 msgstr "Разглеждане на текущия клон…"
 
-#: git-gui.sh:2634
 msgid "Visualize Current Branch's History"
 msgstr "Визуализация на историята на текущия клон"
 
-#: git-gui.sh:2638
 msgid "Visualize All Branch History"
 msgstr "Визуализация на историята на всички клонове"
 
-#: git-gui.sh:2645
 #, tcl-format
 msgid "Browse %s's Files"
 msgstr "Разглеждане на файловете в „%s“"
 
-#: git-gui.sh:2647
 #, tcl-format
 msgid "Visualize %s's History"
 msgstr "Визуализация на историята на „%s“"
 
-#: git-gui.sh:2652 lib/database.tcl:39
 msgid "Database Statistics"
 msgstr "Статистика на базата от данни"
 
-#: git-gui.sh:2655 lib/database.tcl:32
 msgid "Compress Database"
 msgstr "Компресиране на базата от данни"
 
-#: git-gui.sh:2658
 msgid "Verify Database"
 msgstr "Проверка на базата от данни"
 
-#: git-gui.sh:2665 git-gui.sh:2669 git-gui.sh:2673
 msgid "Create Desktop Icon"
 msgstr "Добавяне на икона на работния плот"
 
-#: git-gui.sh:2681 lib/choose_repository.tcl:196 lib/choose_repository.tcl:204
 msgid "Quit"
 msgstr "Спиране на програмата"
 
-#: git-gui.sh:2689
 msgid "Undo"
 msgstr "Отмяна"
 
-#: git-gui.sh:2692
 msgid "Redo"
 msgstr "Повторение"
 
-#: git-gui.sh:2696 git-gui.sh:3297
 msgid "Cut"
 msgstr "Отрязване"
 
-#: git-gui.sh:2699 git-gui.sh:3300 git-gui.sh:3376 git-gui.sh:3471
-#: lib/console.tcl:69
 msgid "Copy"
 msgstr "Копиране"
 
-#: git-gui.sh:2702 git-gui.sh:3303
 msgid "Paste"
 msgstr "Поставяне"
 
-#: git-gui.sh:2705 git-gui.sh:3306 lib/branch_delete.tcl:28
-#: lib/remote_branch_delete.tcl:39
 msgid "Delete"
 msgstr "Изтриване"
 
-#: git-gui.sh:2709 git-gui.sh:3310 git-gui.sh:3475 lib/console.tcl:71
 msgid "Select All"
 msgstr "Избиране на всичко"
 
-#: git-gui.sh:2718
 msgid "Create..."
 msgstr "Създаване…"
 
-#: git-gui.sh:2724
 msgid "Checkout..."
 msgstr "Изтегляне…"
 
-#: git-gui.sh:2730
 msgid "Rename..."
 msgstr "Преименуване…"
 
-#: git-gui.sh:2735
 msgid "Delete..."
 msgstr "Изтриване…"
 
-#: git-gui.sh:2740
 msgid "Reset..."
 msgstr "Отмяна на промените…"
 
-#: git-gui.sh:2750
 msgid "Done"
 msgstr "Готово"
 
-#: git-gui.sh:2752
 msgid "Commit@@verb"
 msgstr "Подаване"
 
-#: git-gui.sh:2761 git-gui.sh:3236
 msgid "Amend Last Commit"
 msgstr "Поправяне на последното подаване"
 
-#: git-gui.sh:2771 git-gui.sh:3197 lib/remote_branch_delete.tcl:97
 msgid "Rescan"
 msgstr "Обновяване"
 
-#: git-gui.sh:2777
 msgid "Stage To Commit"
 msgstr "Към индекса за подаване"
 
-#: git-gui.sh:2783
 msgid "Stage Changed Files To Commit"
 msgstr "Всички променени файлове към индекса за подаване"
 
-#: git-gui.sh:2789
 msgid "Unstage From Commit"
 msgstr "Изваждане от индекса за подаване"
 
-#: git-gui.sh:2795 lib/index.tcl:519
 msgid "Revert Changes"
 msgstr "Връщане на оригинала"
 
-#: git-gui.sh:2803 git-gui.sh:3538 git-gui.sh:3569
 msgid "Show Less Context"
 msgstr "По-малко контекст"
 
-#: git-gui.sh:2807 git-gui.sh:3542 git-gui.sh:3573
 msgid "Show More Context"
 msgstr "Повече контекст"
 
-#: git-gui.sh:2814 git-gui.sh:3210 git-gui.sh:3321
 msgid "Sign Off"
 msgstr "Подписване"
 
-#: git-gui.sh:2830
 msgid "Local Merge..."
 msgstr "Локално сливане…"
 
-#: git-gui.sh:2835
 msgid "Abort Merge..."
 msgstr "Преустановяване на сливане…"
 
-#: git-gui.sh:2847 git-gui.sh:2875
 msgid "Add..."
 msgstr "Добавяне…"
 
-#: git-gui.sh:2851
 msgid "Push..."
 msgstr "Изтласкване…"
 
-#: git-gui.sh:2855
 msgid "Delete Branch..."
 msgstr "Изтриване на клон…"
 
-#: git-gui.sh:2865 git-gui.sh:3504
 msgid "Options..."
 msgstr "Опции…"
 
-#: git-gui.sh:2876
 msgid "Remove..."
 msgstr "Премахване…"
 
-#: git-gui.sh:2885 lib/choose_repository.tcl:57
 msgid "Help"
 msgstr "Помощ"
 
-#: git-gui.sh:2889 git-gui.sh:2893 lib/about.tcl:14
-#: lib/choose_repository.tcl:51 lib/choose_repository.tcl:60
 #, tcl-format
 msgid "About %s"
 msgstr "Относно „%s“"
 
-#: git-gui.sh:2913
 msgid "Online Documentation"
 msgstr "Документация в Интернет"
 
-#: git-gui.sh:2916 lib/choose_repository.tcl:54 lib/choose_repository.tcl:63
 msgid "Show SSH Key"
 msgstr "Показване на ключа за SSH"
 
-#: git-gui.sh:2946 git-gui.sh:3078
 msgid "usage:"
 msgstr "употреба:"
 
-#: git-gui.sh:2950 git-gui.sh:3082
 msgid "Usage"
 msgstr "Употреба"
 
-#: git-gui.sh:3031 lib/blame.tcl:578
 msgid "Error"
 msgstr "Грешка"
 
-#: git-gui.sh:3062
 #, tcl-format
 msgid "fatal: cannot stat path %s: No such file or directory"
 msgstr "ФАТАЛНА ГРЕШКА: пътят „%s“ липсва: такъв файл или директория няма"
 
-#: git-gui.sh:3094
 msgid "Current Branch:"
 msgstr "Текущ клон:"
 
-#: git-gui.sh:3115
 msgid "Unstaged Changes"
 msgstr "Промени извън индекса"
 
-#: git-gui.sh:3137
 msgid "Staged Changes (Will Commit)"
 msgstr "Промени в индекса (за подаване)"
 
-#: git-gui.sh:3203
 msgid "Stage Changed"
 msgstr "Индексът е променен"
 
-#: git-gui.sh:3222 lib/transport.tcl:137
 msgid "Push"
 msgstr "Изтласкване"
 
-#: git-gui.sh:3249
 msgid "Initial Commit Message:"
 msgstr "Първоначално съобщение при подаване:"
 
-#: git-gui.sh:3250
 msgid "Amended Commit Message:"
 msgstr "Поправено съобщение при подаване:"
 
-#: git-gui.sh:3251
 msgid "Amended Initial Commit Message:"
 msgstr "Поправено първоначално съобщение при подаване:"
 
-#: git-gui.sh:3252
 msgid "Amended Merge Commit Message:"
 msgstr "Поправено съобщение при подаване със сливане:"
 
-#: git-gui.sh:3253
 msgid "Merge Commit Message:"
 msgstr "Съобщение при подаване със сливане:"
 
-#: git-gui.sh:3254
 msgid "Commit Message:"
 msgstr "Съобщение при подаване:"
 
-#: git-gui.sh:3313 git-gui.sh:3479 lib/console.tcl:73
 msgid "Copy All"
 msgstr "Копиране на всичко"
 
-#: git-gui.sh:3337 lib/blame.tcl:106
 msgid "File:"
 msgstr "Файл:"
 
-#: git-gui.sh:3385 lib/choose_repository.tcl:659
 msgid "Open"
 msgstr "Отваряне"
 
-#: git-gui.sh:3467
 msgid "Refresh"
 msgstr "Обновяване"
 
-#: git-gui.sh:3488
 msgid "Decrease Font Size"
 msgstr "По-дребен шрифт"
 
-#: git-gui.sh:3492
 msgid "Increase Font Size"
 msgstr "По-едър шрифт"
 
-#: git-gui.sh:3500 lib/blame.tcl:295
 msgid "Encoding"
 msgstr "Кодиране"
 
-#: git-gui.sh:3511
 msgid "Apply/Reverse Hunk"
 msgstr "Прилагане/връщане на парче"
 
-#: git-gui.sh:3516
 msgid "Apply/Reverse Line"
 msgstr "Прилагане/връщане на ред"
 
-#: git-gui.sh:3522 git-gui.sh:3632 git-gui.sh:3643
 msgid "Revert Hunk"
 msgstr "Връщане на парче"
 
-#: git-gui.sh:3527 git-gui.sh:3639 git-gui.sh:3650
 msgid "Revert Line"
 msgstr "Връщане на ред"
 
-#: git-gui.sh:3532 git-gui.sh:3629
 msgid "Undo Last Revert"
 msgstr "Отмяна на последното връщане"
 
-#: git-gui.sh:3551
 msgid "Run Merge Tool"
 msgstr "Изпълнение на програмата за сливане"
 
-#: git-gui.sh:3556
 msgid "Use Remote Version"
 msgstr "Версия от отдалеченото хранилище"
 
-#: git-gui.sh:3560
 msgid "Use Local Version"
 msgstr "Локална версия"
 
-#: git-gui.sh:3564
 msgid "Revert To Base"
 msgstr "Връщане към родителската версия"
 
-#: git-gui.sh:3582
 msgid "Visualize These Changes In The Submodule"
 msgstr "Визуализиране на промените в подмодула"
 
-#: git-gui.sh:3586
 msgid "Visualize Current Branch History In The Submodule"
 msgstr "Визуализация на историята на текущия клон в историята за подмодула"
 
-#: git-gui.sh:3590
 msgid "Visualize All Branch History In The Submodule"
 msgstr "Визуализация на историята на всички клони в историята за подмодула"
 
-#: git-gui.sh:3595
 msgid "Start git gui In The Submodule"
 msgstr "Стартиране на „git gui“ за подмодула"
 
-#: git-gui.sh:3631
 msgid "Unstage Hunk From Commit"
 msgstr "Изваждане на парчето от подаването"
 
-#: git-gui.sh:3635
 msgid "Unstage Lines From Commit"
 msgstr "Изваждане на редовете от подаването"
 
-#: git-gui.sh:3636 git-gui.sh:3647
 msgid "Revert Lines"
 msgstr "Връщане на редовете"
 
-#: git-gui.sh:3638
 msgid "Unstage Line From Commit"
 msgstr "Изваждане на реда от подаването"
 
-#: git-gui.sh:3642
 msgid "Stage Hunk For Commit"
 msgstr "Добавяне на парчето за подаване"
 
-#: git-gui.sh:3646
 msgid "Stage Lines For Commit"
 msgstr "Добавяне на редовете за подаване"
 
-#: git-gui.sh:3649
 msgid "Stage Line For Commit"
 msgstr "Добавяне на реда за подаване"
 
-#: git-gui.sh:3699
 msgid "Initializing..."
 msgstr "Инициализиране…"
 
-#: lib/about.tcl:26
 msgid "git-gui - a graphical user interface for Git."
 msgstr "git-gui — графичен интерфейс за Git."
 
-#: lib/blame.tcl:74
 #, tcl-format
 msgid "%s (%s): File Viewer"
 msgstr "%s (%s): Преглед на файлове"
 
-#: lib/blame.tcl:80
 msgid "Commit:"
 msgstr "Подаване:"
 
-#: lib/blame.tcl:281
 msgid "Copy Commit"
 msgstr "Копиране на подаване"
 
-#: lib/blame.tcl:285
 msgid "Find Text..."
 msgstr "Търсене на текст…"
 
-#: lib/blame.tcl:289
 msgid "Goto Line..."
 msgstr "Към ред…"
 
-#: lib/blame.tcl:298
 msgid "Do Full Copy Detection"
 msgstr "Пълно търсене на копиране"
 
-#: lib/blame.tcl:302
 msgid "Show History Context"
 msgstr "Показване на контекста от историята"
 
-#: lib/blame.tcl:305
 msgid "Blame Parent Commit"
 msgstr "Анотиране на родителското подаване"
 
-#: lib/blame.tcl:469
 #, tcl-format
 msgid "Reading %s..."
 msgstr "Чете се „%s“…"
 
-#: lib/blame.tcl:599
 msgid "Loading copy/move tracking annotations..."
 msgstr "Зареждане на анотациите за проследяване на копирането/преместването…"
 
-#: lib/blame.tcl:616
 msgid "lines annotated"
 msgstr "реда анотирани"
 
-#: lib/blame.tcl:817
 msgid "Loading original location annotations..."
 msgstr "Зареждане на анотациите за първоначалното местоположение…"
 
-#: lib/blame.tcl:820
 msgid "Annotation complete."
 msgstr "Анотирането завърши."
 
-#: lib/blame.tcl:851
 msgid "Busy"
 msgstr "Операцията не е завършила"
 
-#: lib/blame.tcl:852
 msgid "Annotation process is already running."
 msgstr "В момента тече процес на анотиране."
 
-#: lib/blame.tcl:889
 msgid "Running thorough copy detection..."
 msgstr "Изпълнява се цялостен процес на откриване на копиране…"
 
-#: lib/blame.tcl:957
 msgid "Loading annotation..."
 msgstr "Зареждане на анотации…"
 
-#: lib/blame.tcl:1010
 msgid "Author:"
 msgstr "Автор:"
 
-#: lib/blame.tcl:1014
 msgid "Committer:"
 msgstr "Подал:"
 
-#: lib/blame.tcl:1019
 msgid "Original File:"
 msgstr "Първоначален файл:"
 
-#: lib/blame.tcl:1067
 msgid "Cannot find HEAD commit:"
 msgstr "Подаването за връх „HEAD“ не може да се открие:"
 
-#: lib/blame.tcl:1122
 msgid "Cannot find parent commit:"
 msgstr "Родителското подаване не може да се открие"
 
-#: lib/blame.tcl:1137
 msgid "Unable to display parent"
 msgstr "Родителят не може да се покаже"
 
-#: lib/blame.tcl:1138 lib/diff.tcl:319
 msgid "Error loading diff:"
 msgstr "Грешка при зареждане на разлика:"
 
-#: lib/blame.tcl:1279
 msgid "Originally By:"
 msgstr "Първоначално от:"
 
-#: lib/blame.tcl:1285
 msgid "In File:"
 msgstr "Във файл:"
 
-#: lib/blame.tcl:1290
 msgid "Copied Or Moved Here By:"
 msgstr "Копирано или преместено тук от:"
 
-#: lib/branch_checkout.tcl:15
 #, tcl-format
 msgid "%s (%s): Checkout Branch"
 msgstr "%s (%s): Клон за изтегляне"
 
-#: lib/branch_checkout.tcl:20
 msgid "Checkout Branch"
 msgstr "Клон за изтегляне"
 
-#: lib/branch_checkout.tcl:25
 msgid "Checkout"
 msgstr "Изтегляне"
 
-#: lib/branch_checkout.tcl:29 lib/branch_create.tcl:37 lib/branch_delete.tcl:34
-#: lib/branch_rename.tcl:32 lib/browser.tcl:289 lib/checkout_op.tcl:571
-#: lib/choose_font.tcl:44 lib/merge.tcl:169 lib/option.tcl:127
-#: lib/remote_add.tcl:34 lib/remote_branch_delete.tcl:43 lib/tools_dlg.tcl:41
-#: lib/tools_dlg.tcl:202 lib/tools_dlg.tcl:345 lib/transport.tcl:141
 msgid "Cancel"
 msgstr "Отказване"
 
-#: lib/branch_checkout.tcl:34 lib/browser.tcl:294 lib/tools_dlg.tcl:321
 msgid "Revision"
 msgstr "Версия"
 
-#: lib/branch_checkout.tcl:38 lib/branch_create.tcl:67 lib/option.tcl:298
 msgid "Options"
 msgstr "Опции"
 
-#: lib/branch_checkout.tcl:41 lib/branch_create.tcl:90
 msgid "Fetch Tracking Branch"
 msgstr "Изтегляне на промените от следения клон"
 
-#: lib/branch_checkout.tcl:46
 msgid "Detach From Local Branch"
 msgstr "Изтриване от локалния клон"
 
-#: lib/branch_create.tcl:23
 #, tcl-format
 msgid "%s (%s): Create Branch"
 msgstr "%s (%s): Създаване на клон"
 
-#: lib/branch_create.tcl:28
 msgid "Create New Branch"
 msgstr "Създаване на нов клон"
 
-#: lib/branch_create.tcl:33 lib/choose_repository.tcl:353
 msgid "Create"
 msgstr "Създаване"
 
-#: lib/branch_create.tcl:42
 msgid "Branch Name"
 msgstr "Име на клона"
 
-#: lib/branch_create.tcl:44 lib/remote_add.tcl:41 lib/tools_dlg.tcl:51
 msgid "Name:"
 msgstr "Име:"
 
-#: lib/branch_create.tcl:56
 msgid "Match Tracking Branch Name"
 msgstr "Съвпадане по името на следения клон"
 
-#: lib/branch_create.tcl:64
 msgid "Starting Revision"
 msgstr "Начална версия"
 
-#: lib/branch_create.tcl:70
 msgid "Update Existing Branch:"
 msgstr "Обновяване на съществуващ клон:"
 
-#: lib/branch_create.tcl:73
 msgid "No"
 msgstr "Не"
 
-#: lib/branch_create.tcl:78
 msgid "Fast Forward Only"
 msgstr "Само тривиално превъртащо сливане"
 
-#: lib/branch_create.tcl:83 lib/checkout_op.tcl:563
 msgid "Reset"
 msgstr "Отначало"
 
-#: lib/branch_create.tcl:95
 msgid "Checkout After Creation"
 msgstr "Преминаване към клона след създаването му"
 
-#: lib/branch_create.tcl:130
 msgid "Please select a tracking branch."
 msgstr "Изберете клон за следени."
 
-#: lib/branch_create.tcl:139
 #, tcl-format
 msgid "Tracking branch %s is not a branch in the remote repository."
 msgstr "Следящият клон — „%s“, не съществува в отдалеченото хранилище."
 
-#: lib/branch_create.tcl:152 lib/branch_rename.tcl:88
 msgid "Please supply a branch name."
 msgstr "Дайте име на клона."
 
-#: lib/branch_create.tcl:163 lib/branch_rename.tcl:108
 #, tcl-format
 msgid "'%s' is not an acceptable branch name."
 msgstr "„%s“ не може да се използва за име на клон."
 
-#: lib/branch_delete.tcl:16
 #, tcl-format
 msgid "%s (%s): Delete Branch"
 msgstr "%s (%s): Изтриване на клон"
 
-#: lib/branch_delete.tcl:21
 msgid "Delete Local Branch"
 msgstr "Изтриване на локален клон"
 
-#: lib/branch_delete.tcl:39
 msgid "Local Branches"
 msgstr "Локални клони"
 
-#: lib/branch_delete.tcl:51
 msgid "Delete Only If Merged Into"
 msgstr "Изтриване, само ако промените са слети и другаде"
 
-#: lib/branch_delete.tcl:53 lib/remote_branch_delete.tcl:116
 msgid "Always (Do not perform merge checks)"
 msgstr "Винаги (без проверка за сливане)"
 
-#: lib/branch_delete.tcl:103
 #, tcl-format
 msgid "The following branches are not completely merged into %s:"
 msgstr "Не всички промени в клоните са слети в „%s“:"
 
-#: lib/branch_delete.tcl:115 lib/remote_branch_delete.tcl:214
 msgid ""
 "Recovering deleted branches is difficult.\n"
 "\n"
@@ -821,12 +620,10 @@ msgstr ""
 "\n"
 "Сигурни ли сте, че искате да триете?"
 
-#: lib/branch_delete.tcl:131
 #, tcl-format
 msgid " - %s:"
 msgstr " — „%s:“"
 
-#: lib/branch_delete.tcl:141
 #, tcl-format
 msgid ""
 "Failed to delete branches:\n"
@@ -835,100 +632,76 @@ msgstr ""
 "Неуспешно триене на клони:\n"
 "%s"
 
-#: lib/branch_rename.tcl:15
 #, tcl-format
 msgid "%s (%s): Rename Branch"
 msgstr "%s (%s): Преименуване на клон"
 
-#: lib/branch_rename.tcl:23
 msgid "Rename Branch"
 msgstr "Преименуване на клон"
 
-#: lib/branch_rename.tcl:28
 msgid "Rename"
 msgstr "Преименуване"
 
-#: lib/branch_rename.tcl:38
 msgid "Branch:"
 msgstr "Клон:"
 
-#: lib/branch_rename.tcl:42
 msgid "New Name:"
 msgstr "Ново име:"
 
-#: lib/branch_rename.tcl:77
 msgid "Please select a branch to rename."
 msgstr "Изберете клон за преименуване."
 
-#: lib/branch_rename.tcl:98 lib/checkout_op.tcl:202
 #, tcl-format
 msgid "Branch '%s' already exists."
 msgstr "Клонът „%s“ вече съществува."
 
-#: lib/branch_rename.tcl:119
 #, tcl-format
 msgid "Failed to rename '%s'."
 msgstr "Неуспешно преименуване на „%s“."
 
-#: lib/browser.tcl:17
 msgid "Starting..."
 msgstr "Стартиране…"
 
-#: lib/browser.tcl:27
 #, tcl-format
 msgid "%s (%s): File Browser"
 msgstr "%s (%s): Файлов браузър"
 
-#: lib/browser.tcl:130 lib/browser.tcl:147
 #, tcl-format
 msgid "Loading %s..."
 msgstr "Зареждане на „%s“…"
 
-#: lib/browser.tcl:191
 msgid "[Up To Parent]"
 msgstr "[Към родителя]"
 
-#: lib/browser.tcl:272
 #, tcl-format
 msgid "%s (%s): Browse Branch Files"
 msgstr "%s (%s): Разглеждане на файловете в клона"
 
-#: lib/browser.tcl:279
 msgid "Browse Branch Files"
 msgstr "Разглеждане на файловете в клона"
 
-#: lib/browser.tcl:285 lib/choose_repository.tcl:368
-#: lib/choose_repository.tcl:454 lib/choose_repository.tcl:463
-#: lib/choose_repository.tcl:674
 msgid "Browse"
 msgstr "Разглеждане"
 
-#: lib/checkout_op.tcl:85
 #, tcl-format
 msgid "Fetching %s from %s"
 msgstr "Доставяне на „%s“ от „%s“"
 
-#: lib/checkout_op.tcl:133
 #, tcl-format
 msgid "fatal: Cannot resolve %s"
 msgstr "фатална грешка: „%s“ не може да се открие"
 
-#: lib/checkout_op.tcl:146 lib/console.tcl:81 lib/database.tcl:29
-#: lib/sshkey.tcl:55
 msgid "Close"
 msgstr "Затваряне"
 
-#: lib/checkout_op.tcl:175
 #, tcl-format
 msgid "Branch '%s' does not exist."
 msgstr "Клонът „%s“ не съществува."
 
-#: lib/checkout_op.tcl:194
 #, tcl-format
 msgid "Failed to configure simplified git-pull for '%s'."
 msgstr "Неуспешно настройване на опростен git-pull за „%s“."
 
-#: lib/checkout_op.tcl:229
 #, tcl-format
 msgid ""
 "Branch '%s' already exists.\n"
@@ -941,21 +714,17 @@ msgstr ""
 "Той не може да се слее тривиално до „%s“.\n"
 "Необходимо е сливане."
 
-#: lib/checkout_op.tcl:243
 #, tcl-format
 msgid "Merge strategy '%s' not supported."
 msgstr "Стратегия за сливане „%s“ не се поддържа."
 
-#: lib/checkout_op.tcl:262
 #, tcl-format
 msgid "Failed to update '%s'."
 msgstr "Неуспешно обновяване на „%s“."
 
-#: lib/checkout_op.tcl:274
 msgid "Staging area (index) is already locked."
 msgstr "Индексът вече е заключен."
 
-#: lib/checkout_op.tcl:289
 msgid ""
 "Last scanned state does not match repository state.\n"
 "\n"
@@ -972,31 +741,25 @@ msgstr ""
 "\n"
 "Автоматично ще започне нова проверка.\n"
 
-#: lib/checkout_op.tcl:345
 #, tcl-format
 msgid "Updating working directory to '%s'..."
 msgstr "Работната директория се привежда към „%s“…"
 
-#: lib/checkout_op.tcl:346
 msgid "files checked out"
 msgstr "файла са изтеглени"
 
-#: lib/checkout_op.tcl:378
 #, tcl-format
 msgid "Aborted checkout of '%s' (file level merging is required)."
 msgstr ""
 "Преустановяване на изтеглянето на „%s“ (необходимо е пофайлово сливане)."
 
-#: lib/checkout_op.tcl:379
 msgid "File level merge required."
 msgstr "Необходимо е пофайлово сливане."
 
-#: lib/checkout_op.tcl:383
 #, tcl-format
 msgid "Staying on branch '%s'."
 msgstr "Оставане върху клона „%s“."
 
-#: lib/checkout_op.tcl:454
 msgid ""
 "You are no longer on a local branch.\n"
 "\n"
@@ -1007,31 +770,25 @@ msgstr ""
 "\n"
 "Ако искате да сте на клон, създайте базиран на „Това несвързано изтегляне“."
 
-#: lib/checkout_op.tcl:505 lib/checkout_op.tcl:509
 #, tcl-format
 msgid "Checked out '%s'."
 msgstr "„%s“ е изтеглен."
 
-#: lib/checkout_op.tcl:527
 #, tcl-format
 msgid "Resetting '%s' to '%s' will lose the following commits:"
 msgstr ""
 "Зануляването на „%s“ към „%s“ ще доведе до загубването на следните подавания:"
 
-#: lib/checkout_op.tcl:549
 msgid "Recovering lost commits may not be easy."
 msgstr "Възстановяването на загубените подавания може да е трудно."
 
-#: lib/checkout_op.tcl:554
 #, tcl-format
 msgid "Reset '%s'?"
 msgstr "Зануляване на „%s“?"
 
-#: lib/checkout_op.tcl:559 lib/merge.tcl:161 lib/tools_dlg.tcl:336
 msgid "Visualize"
 msgstr "Визуализация"
 
-#: lib/checkout_op.tcl:627
 #, tcl-format
 msgid ""
 "Failed to set current branch.\n"
@@ -1049,23 +806,18 @@ msgstr ""
 "Това състояние е аварийно и не трябва да се случва. Програмата „%s“ ще "
 "преустанови работа."
 
-#: lib/choose_font.tcl:40
 msgid "Select"
 msgstr "Избор"
 
-#: lib/choose_font.tcl:54
 msgid "Font Family"
 msgstr "Шрифт"
 
-#: lib/choose_font.tcl:75
 msgid "Font Size"
 msgstr "Размер"
 
-#: lib/choose_font.tcl:92
 msgid "Font Example"
 msgstr "Мостра"
 
-#: lib/choose_font.tcl:104
 msgid ""
 "This is example text.\n"
 "If you like this text, it can be your font."
@@ -1073,181 +825,137 @@ msgstr ""
 "Това е примерен текст.\n"
 "Ако ви харесва как изглежда, изберете шрифта."
 
-#: lib/choose_repository.tcl:35
 msgid "Git Gui"
 msgstr "ГПИ на Git"
 
-#: lib/choose_repository.tcl:94 lib/choose_repository.tcl:358
 msgid "Create New Repository"
 msgstr "Създаване на ново хранилище"
 
-#: lib/choose_repository.tcl:100
 msgid "New..."
 msgstr "Ново…"
 
-#: lib/choose_repository.tcl:107 lib/choose_repository.tcl:441
 msgid "Clone Existing Repository"
 msgstr "Клониране на съществуващо хранилище"
 
-#: lib/choose_repository.tcl:118
 msgid "Clone..."
 msgstr "Клониране…"
 
-#: lib/choose_repository.tcl:125 lib/choose_repository.tcl:664
 msgid "Open Existing Repository"
 msgstr "Отваряне на съществуващо хранилище"
 
-#: lib/choose_repository.tcl:131
 msgid "Open..."
 msgstr "Отваряне…"
 
-#: lib/choose_repository.tcl:144
 msgid "Recent Repositories"
 msgstr "Скоро ползвани"
 
-#: lib/choose_repository.tcl:154
 msgid "Open Recent Repository:"
 msgstr "Отваряне на хранилище ползвано наскоро:"
 
-#: lib/choose_repository.tcl:317 lib/choose_repository.tcl:324
 #, tcl-format
 msgid "Failed to create repository %s:"
 msgstr "Неуспешно създаване на хранилището „%s“:"
 
-#: lib/choose_repository.tcl:363
 msgid "Directory:"
 msgstr "Директория:"
 
-#: lib/choose_repository.tcl:393 lib/choose_repository.tcl:518
-#: lib/choose_repository.tcl:698
 msgid "Git Repository"
 msgstr "Хранилище на Git"
 
-#: lib/choose_repository.tcl:418
 #, tcl-format
 msgid "Directory %s already exists."
 msgstr "Вече съществува директория „%s“."
 
-#: lib/choose_repository.tcl:422
 #, tcl-format
 msgid "File %s already exists."
 msgstr "Вече съществува файл „%s“."
 
-#: lib/choose_repository.tcl:436
 msgid "Clone"
 msgstr "Клониране"
 
-#: lib/choose_repository.tcl:449
 msgid "Source Location:"
 msgstr "Адрес на източника:"
 
-#: lib/choose_repository.tcl:458
 msgid "Target Directory:"
 msgstr "Целева директория:"
 
-#: lib/choose_repository.tcl:468
 msgid "Clone Type:"
 msgstr "Вид клониране:"
 
-#: lib/choose_repository.tcl:473
 msgid "Standard (Fast, Semi-Redundant, Hardlinks)"
 msgstr "Стандартно (бързо, частично споделяне на файлове, твърди връзки)"
 
-#: lib/choose_repository.tcl:478
 msgid "Full Copy (Slower, Redundant Backup)"
 msgstr "Пълно (бавно, пълноценно резервно копие)"
 
-#: lib/choose_repository.tcl:483
 msgid "Shared (Fastest, Not Recommended, No Backup)"
 msgstr "Споделено (най-бързо, не се препоръчва, не прави резервно копие)"
 
-#: lib/choose_repository.tcl:490
 msgid "Recursively clone submodules too"
 msgstr "Рекурсивно клониране и на подмодулите"
 
-#: lib/choose_repository.tcl:524 lib/choose_repository.tcl:704
-#: lib/choose_repository.tcl:712
 #, tcl-format
 msgid "Not a Git repository: %s"
 msgstr "Това не е хранилище на Git: %s"
 
-#: lib/choose_repository.tcl:571
 msgid "Hardlinks are unavailable.  Falling back to copying."
 msgstr "Не се поддържат твърди връзки. Преминава се към копиране."
 
-#: lib/choose_repository.tcl:579
 msgid "Standard only available for local repository."
 msgstr "Само локални хранилища може да се клонират стандартно"
 
-#: lib/choose_repository.tcl:583
 msgid "Shared only available for local repository."
 msgstr "Само локални хранилища може да се клонират споделено"
 
-#: lib/choose_repository.tcl:590
 #, tcl-format
 msgid "Location %s already exists."
 msgstr "Местоположението „%s“ вече съществува."
 
-#: lib/choose_repository.tcl:613
 #, tcl-format
 msgid "Cloning from %s"
 msgstr "Клониране на „%s“"
 
-#: lib/choose_repository.tcl:619 lib/choose_repository.tcl:625
 msgid "Clone failed."
 msgstr "Неуспешно клониране."
 
-#: lib/choose_repository.tcl:669
 msgid "Repository:"
 msgstr "Хранилище:"
 
-#: lib/choose_repository.tcl:718
 #, tcl-format
 msgid "Failed to open repository %s:"
 msgstr "Неуспешно отваряне на хранилището „%s“:"
 
-#: lib/choose_rev.tcl:52
 msgid "This Detached Checkout"
 msgstr "Това несвързано изтегляне"
 
-#: lib/choose_rev.tcl:59
 msgid "Revision Expression:"
 msgstr "Израз за версия:"
 
-#: lib/choose_rev.tcl:71
 msgid "Local Branch"
 msgstr "Локален клон"
 
-#: lib/choose_rev.tcl:76
 msgid "Tracking Branch"
 msgstr "Следящ клон"
 
-#: lib/choose_rev.tcl:81 lib/choose_rev.tcl:534
 msgid "Tag"
 msgstr "Етикет"
 
-#: lib/choose_rev.tcl:312
 #, tcl-format
 msgid "Invalid revision: %s"
 msgstr "Неправилна версия: %s"
 
-#: lib/choose_rev.tcl:333
 msgid "No revision selected."
 msgstr "Не е избрана версия."
 
-#: lib/choose_rev.tcl:341
 msgid "Revision expression is empty."
 msgstr "Изразът за версия е празен."
 
-#: lib/choose_rev.tcl:527
 msgid "Updated"
 msgstr "Обновен"
 
-#: lib/choose_rev.tcl:555
 msgid "URL"
 msgstr "Адрес"
 
-#: lib/commit.tcl:9
 msgid ""
 "There is nothing to amend.\n"
 "\n"
@@ -1259,7 +967,6 @@ msgstr ""
 "Ще създадете първоначалното подаване. Преди него няма други подавания, които "
 "да поправите.\n"
 
-#: lib/commit.tcl:18
 msgid ""
 "Cannot amend while merging.\n"
 "\n"
@@ -1272,24 +979,19 @@ msgstr ""
 "В момента все още не сте завършили операция по сливане. Не може да поправите "
 "предишното подаване, освен ако първо не преустановите текущото сливане.\n"
 
-#: lib/commit.tcl:56
 msgid "Error loading commit data for amend:"
 msgstr "Грешка при зареждане на данните от подаване, които да се поправят:"
 
-#: lib/commit.tcl:83
 msgid "Unable to obtain your identity:"
 msgstr "Идентификацията ви не може да се определи:"
 
-#: lib/commit.tcl:88
 msgid "Invalid GIT_COMMITTER_IDENT:"
 msgstr "Неправилно поле „GIT_COMMITTER_IDENT“:"
 
-#: lib/commit.tcl:138
 #, tcl-format
 msgid "warning: Tcl does not support encoding '%s'."
 msgstr "предупреждение: Tcl не поддържа кодирането „%s“."
 
-#: lib/commit.tcl:158
 msgid ""
 "Last scanned state does not match repository state.\n"
 "\n"
@@ -1306,7 +1008,6 @@ msgstr ""
 "\n"
 "Автоматично ще започне нова проверка.\n"
 
-#: lib/commit.tcl:182
 #, tcl-format
 msgid ""
 "Unmerged files cannot be committed.\n"
@@ -1319,7 +1020,6 @@ msgstr ""
 "Във файла „%s“ има конфликти при сливане. За да го подадете, трябва първо да "
 "коригирате конфликтите и да добавите файла към индекса за подаване.\n"
 
-#: lib/commit.tcl:190
 #, tcl-format
 msgid ""
 "Unknown file state %s detected.\n"
@@ -1330,7 +1030,6 @@ msgstr ""
 "\n"
 "Файлът „%s“ не може да се подаде чрез текущата програма.\n"
 
-#: lib/commit.tcl:198
 msgid ""
 "No changes to commit.\n"
 "\n"
@@ -1340,7 +1039,6 @@ msgstr ""
 "\n"
 "Трябва да добавите поне един файл към индекса, за да подадете.\n"
 
-#: lib/commit.tcl:222
 msgid ""
 "Please supply a commit message.\n"
 "\n"
@@ -1358,15 +1056,12 @@ msgstr ""
 "● Втори ред: празен.\n"
 "● Останалите редове: опишете защо се налага тази промяна.\n"
 
-#: lib/commit.tcl:253
 msgid "Calling pre-commit hook..."
 msgstr "Изпълняване на куката преди подаване…"
 
-#: lib/commit.tcl:268
 msgid "Commit declined by pre-commit hook."
 msgstr "Подаването е отхвърлено от куката преди подаване."
 
-#: lib/commit.tcl:287
 msgid ""
 "You are about to commit on a detached head. This is a potentially dangerous "
 "thing to do because if you switch to another branch you will lose your "
@@ -1382,32 +1077,25 @@ msgstr ""
 " \n"
 "Сигурни ли сте, че искате да извършите текущото подаване?"
 
-#: lib/commit.tcl:308
 msgid "Calling commit-msg hook..."
 msgstr "Изпълняване на куката за съобщението при подаване…"
 
-#: lib/commit.tcl:323
 msgid "Commit declined by commit-msg hook."
 msgstr "Подаването е отхвърлено от куката за съобщението при подаване."
 
-#: lib/commit.tcl:336
 msgid "Committing changes..."
 msgstr "Подаване на промените…"
 
-#: lib/commit.tcl:354
 msgid "write-tree failed:"
 msgstr "неуспешно запазване на дървото (write-tree):"
 
-#: lib/commit.tcl:355 lib/commit.tcl:405 lib/commit.tcl:432
 msgid "Commit failed."
 msgstr "Неуспешно подаване."
 
-#: lib/commit.tcl:372
 #, tcl-format
 msgid "Commit %s appears to be corrupt"
 msgstr "Подаването „%s“ изглежда повредено"
 
-#: lib/commit.tcl:377
 msgid ""
 "No changes to commit.\n"
 "\n"
@@ -1422,83 +1110,63 @@ msgstr ""
 "\n"
 "Автоматично ще започне нова проверка.\n"
 
-#: lib/commit.tcl:384
 msgid "No changes to commit."
 msgstr "Няма промени за подаване."
 
-#: lib/commit.tcl:404
 msgid "commit-tree failed:"
 msgstr "неуспешно подаване на дървото (commit-tree):"
 
-#: lib/commit.tcl:431
 msgid "update-ref failed:"
 msgstr "неуспешно обновяване на указателите (update-ref):"
 
-#: lib/commit.tcl:525
 #, tcl-format
 msgid "Created commit %s: %s"
 msgstr "Успешно подаване %s: %s"
 
-#: lib/console.tcl:59
 msgid "Working... please wait..."
 msgstr "В момента се извършва действие, изчакайте…"
 
-#: lib/console.tcl:185
 msgid "Success"
 msgstr "Успех"
 
-#: lib/console.tcl:199
 msgid "Error: Command Failed"
 msgstr "Грешка: неуспешно изпълнение на команда"
 
-#: lib/database.tcl:41
 msgid "Number of loose objects"
 msgstr "Брой непакетирани обекти"
 
-#: lib/database.tcl:42
 msgid "Disk space used by loose objects"
 msgstr "Дисково пространство заето от непакетирани обекти"
 
-#: lib/database.tcl:43
 msgid "Number of packed objects"
 msgstr "Брой пакетирани обекти"
 
-#: lib/database.tcl:44
 msgid "Number of packs"
 msgstr "Брой пакети"
 
-#: lib/database.tcl:45
 msgid "Disk space used by packed objects"
 msgstr "Дисково пространство заето от пакетирани обекти"
 
-#: lib/database.tcl:46
 msgid "Packed objects waiting for pruning"
 msgstr "Пакетирани обекти за окастряне"
 
-#: lib/database.tcl:47
 msgid "Garbage files"
 msgstr "Файлове за боклука"
 
-#: lib/database.tcl:56 lib/option.tcl:182 lib/option.tcl:197 lib/option.tcl:220
-#: lib/option.tcl:270
 #, tcl-format
 msgid "%s:"
 msgstr "%s:"
 
-#: lib/database.tcl:65
 #, tcl-format
 msgid "%s (%s): Database Statistics"
 msgstr "%s (%s): Статистика на базата от данни"
 
-#: lib/database.tcl:71
 msgid "Compressing the object database"
 msgstr "Компресиране на базата с данни за обектите"
 
-#: lib/database.tcl:82
 msgid "Verifying the object database with fsck-objects"
 msgstr "Проверка на базата с данни за обектите с програмата „fsck-objects“"
 
-#: lib/database.tcl:106
 #, tcl-format
 msgid ""
 "This repository currently has approximately %i loose objects.\n"
@@ -1515,12 +1183,10 @@ msgstr ""
 "\n"
 "Да се започне ли компресирането?"
 
-#: lib/date.tcl:25
 #, tcl-format
 msgid "Invalid date from Git: %s"
 msgstr "Неправилни данни от Git: %s"
 
-#: lib/diff.tcl:72
 msgid ""
 "* No differences detected; stage the file to de-list it from Unstaged "
 "Changes.\n"
@@ -1528,16 +1194,13 @@ msgstr ""
 "● Няма разлики. Добавете файла към индекса, за да се извади от промените "
 "извън индекса.\n"
 
-#: lib/diff.tcl:73
 msgid "* Click to find other files that may have the same state.\n"
 msgstr "● Натиснете, за да потърсите други файлове в това състояние.\n"
 
-#: lib/diff.tcl:104
 #, tcl-format
 msgid "Loading diff of %s..."
 msgstr "Зареждане на разликите в „%s“…"
 
-#: lib/diff.tcl:130
 msgid ""
 "LOCAL: deleted\n"
 "REMOTE:\n"
@@ -1545,7 +1208,6 @@ msgstr ""
 "ЛОКАЛНО: изтрит\n"
 "ОТДАЛЕЧЕНО:\n"
 
-#: lib/diff.tcl:135
 msgid ""
 "REMOTE: deleted\n"
 "LOCAL:\n"
@@ -1553,32 +1215,25 @@ msgstr ""
 "ОТДАЛЕЧЕНО: изтрит\n"
 "ЛОКАЛНО:\n"
 
-#: lib/diff.tcl:142
 msgid "LOCAL:\n"
 msgstr "ЛОКАЛНО:\n"
 
-#: lib/diff.tcl:145
 msgid "REMOTE:\n"
 msgstr "ОТДАЛЕЧЕНО:\n"
 
-#: lib/diff.tcl:207 lib/diff.tcl:318
 #, tcl-format
 msgid "Unable to display %s"
 msgstr "Файлът „%s“ не може да се покаже"
 
-#: lib/diff.tcl:208
 msgid "Error loading file:"
 msgstr "Грешка при зареждане на файл:"
 
-#: lib/diff.tcl:214
 msgid "Git Repository (subproject)"
 msgstr "Хранилище на Git (подмодул)"
 
-#: lib/diff.tcl:226
 msgid "* Binary file (not showing content)."
 msgstr "● Двоичен файл (съдържанието не се показва)."
 
-#: lib/diff.tcl:231
 #, tcl-format
 msgid ""
 "* Untracked file is %d bytes.\n"
@@ -1587,7 +1242,6 @@ msgstr ""
 "● Неследеният файл е %d байта.\n"
 "● Показват се само първите %d байта.\n"
 
-#: lib/diff.tcl:237
 #, tcl-format
 msgid ""
 "\n"
@@ -1598,80 +1252,62 @@ msgstr ""
 "● Неследеният файл е отрязан дотук от програмата „%s“.\n"
 "● Използвайте външен редактор, за да видите целия файл.\n"
 
-#: lib/diff.tcl:554
 msgid "Failed to unstage selected hunk."
 msgstr "Избраното парче не може да се извади от индекса."
 
-#: lib/diff.tcl:562
 msgid "Failed to revert selected hunk."
 msgstr "Избраното парче не може да се върне."
 
-#: lib/diff.tcl:565
 msgid "Failed to stage selected hunk."
 msgstr "Избраното парче не може да се добави към индекса."
 
-#: lib/diff.tcl:658
 msgid "Failed to unstage selected line."
 msgstr "Избраният ред не може да се извади от индекса."
 
-#: lib/diff.tcl:667
 msgid "Failed to revert selected line."
 msgstr "Избраният ред не може да се върне."
 
-#: lib/diff.tcl:671
 msgid "Failed to stage selected line."
 msgstr "Избраният ред не може да се добави към индекса."
 
-#: lib/diff.tcl:860
 msgid "Failed to undo last revert."
 msgstr "Неуспешна отмяна на последното връщане."
 
-#: lib/encoding.tcl:443
 msgid "Default"
 msgstr "Стандартното"
 
-#: lib/encoding.tcl:448
 #, tcl-format
 msgid "System (%s)"
 msgstr "Системното (%s)"
 
-#: lib/encoding.tcl:459 lib/encoding.tcl:465
 msgid "Other"
 msgstr "Друго"
 
-#: lib/error.tcl:20
 #, tcl-format
 msgid "%s: error"
 msgstr "%s: грешка"
 
-#: lib/error.tcl:36
 #, tcl-format
 msgid "%s: warning"
 msgstr "%s: предупреждение"
 
-#: lib/error.tcl:79
 #, tcl-format
 msgid "%s hook failed:"
 msgstr "%s: грешка от куката"
 
-#: lib/error.tcl:95
 msgid "You must correct the above errors before committing."
 msgstr "Преди да можете да подадете, коригирайте горните грешки."
 
-#: lib/error.tcl:115
 #, tcl-format
 msgid "%s (%s): error"
 msgstr "%s (%s): грешка"
 
-#: lib/index.tcl:6
 msgid "Unable to unlock the index."
 msgstr "Индексът не може да се отключи."
 
-#: lib/index.tcl:28
 msgid "Index Error"
 msgstr "Грешка в индекса"
 
-#: lib/index.tcl:30
 msgid ""
 "Updating the Git index failed.  A rescan will be automatically started to "
 "resynchronize git-gui."
@@ -1679,123 +1315,96 @@ msgstr ""
 "Неуспешно обновяване на индекса на Git. Автоматично ще започне нова проверка "
 "за синхронизирането на git-gui."
 
-#: lib/index.tcl:41
 msgid "Continue"
 msgstr "Продължаване"
 
-#: lib/index.tcl:44
 msgid "Unlock Index"
 msgstr "Отключване на индекса"
 
-#: lib/index.tcl:75 lib/index.tcl:144 lib/index.tcl:218 lib/index.tcl:587
 msgid "files"
 msgstr "файлове"
 
-#: lib/index.tcl:324
 msgid "Unstaging selected files from commit"
 msgstr "Изваждане на избраните файлове от подаването"
 
-#: lib/index.tcl:328
 #, tcl-format
 msgid "Unstaging %s from commit"
 msgstr "Изваждане на „%s“ от подаването"
 
-#: lib/index.tcl:367
 msgid "Ready to commit."
 msgstr "Готовност за подаване."
 
-#: lib/index.tcl:376
 msgid "Adding selected files"
 msgstr "Добавяне на избраните файлове"
 
-#: lib/index.tcl:380
 #, tcl-format
 msgid "Adding %s"
 msgstr "Добавяне на „%s“"
 
-#: lib/index.tcl:410
 #, tcl-format
 msgid "Stage %d untracked files?"
 msgstr "Да се добавят ли %d неследени файла към индекса?"
 
-#: lib/index.tcl:418
 msgid "Adding all changed files"
 msgstr "Добавяне на всички променени файлове"
 
-#: lib/index.tcl:501
 #, tcl-format
 msgid "Revert changes in file %s?"
 msgstr "Да се махнат ли промените във файла „%s“?"
 
-#: lib/index.tcl:506
 #, tcl-format
 msgid "Revert changes in these %i files?"
 msgstr "Да се махнат ли промените в тези %i файла?"
 
-#: lib/index.tcl:515
 msgid "Any unstaged changes will be permanently lost by the revert."
 msgstr ""
 "Всички промени, които не са били добавени в индекса, ще се загубят "
 "безвъзвратно."
 
-#: lib/index.tcl:518 lib/index.tcl:562
 msgid "Do Nothing"
 msgstr "Нищо да не се прави"
 
-#: lib/index.tcl:544
 #, tcl-format
 msgid "Delete untracked file %s?"
 msgstr "Да се изтрие ли неследеният файл „%s“?"
 
-#: lib/index.tcl:549
 #, tcl-format
 msgid "Delete these %i untracked files?"
 msgstr "Да се изтрият ли тези %d неследени файла?"
 
-#: lib/index.tcl:559
 msgid "Files will be permanently deleted."
 msgstr "Файловете ще се изтрият окончателно."
 
-#: lib/index.tcl:563
 msgid "Delete Files"
 msgstr "Изтриване на файлове"
 
-#: lib/index.tcl:586
 msgid "Deleting"
 msgstr "Изтриване"
 
-#: lib/index.tcl:665
 msgid "Encountered errors deleting files:\n"
 msgstr "Грешки при изтриване на файловете:\n"
 
-#: lib/index.tcl:674
 #, tcl-format
 msgid "None of the %d selected files could be deleted."
 msgstr "Никой от избраните %d файла не бе изтрит."
 
-#: lib/index.tcl:679
 #, tcl-format
 msgid "%d of the %d selected files could not be deleted."
 msgstr "%d от избраните %d файла не бяха изтрити."
 
-#: lib/index.tcl:726
 msgid "Reverting selected files"
 msgstr "Махане на промените в избраните файлове"
 
-#: lib/index.tcl:730
 #, tcl-format
 msgid "Reverting %s"
 msgstr "Махане на промените в „%s“"
 
-#: lib/line.tcl:16
 msgid "Goto Line:"
 msgstr "Към ред:"
 
-#: lib/line.tcl:22
 msgid "Go"
 msgstr "Към"
 
-#: lib/merge.tcl:13
 msgid ""
 "Cannot merge while amending.\n"
 "\n"
@@ -1806,7 +1415,6 @@ msgstr ""
 "Трябва да завършите поправянето на текущото подаване, преди да започнете "
 "сливане.\n"
 
-#: lib/merge.tcl:27
 msgid ""
 "Last scanned state does not match repository state.\n"
 "\n"
@@ -1823,7 +1431,6 @@ msgstr ""
 "Автоматично ще започне нова проверка.\n"
 "\n"
 
-#: lib/merge.tcl:45
 #, tcl-format
 msgid ""
 "You are in the middle of a conflicted merge.\n"
@@ -1841,7 +1448,6 @@ msgstr ""
 "завършите текущото сливане чрез подаване. Чак тогава може да започнете ново "
 "сливане.\n"
 
-#: lib/merge.tcl:55
 #, tcl-format
 msgid ""
 "You are in the middle of a change.\n"
@@ -1858,39 +1464,31 @@ msgstr ""
 "Трябва да завършите текущото подаване, преди да започнете сливане. Така ще "
 "можете лесно да преустановите сливането, ако възникне нужда.\n"
 
-#: lib/merge.tcl:108
 #, tcl-format
 msgid "%s of %s"
 msgstr "%s от общо %s"
 
-#: lib/merge.tcl:117
 #, tcl-format
 msgid "Merging %s and %s..."
 msgstr "Сливане на „%s“ и „%s“…"
 
-#: lib/merge.tcl:128
 msgid "Merge completed successfully."
 msgstr "Сливането завърши успешно."
 
-#: lib/merge.tcl:130
 msgid "Merge failed.  Conflict resolution is required."
 msgstr "Неуспешно сливане — има конфликти за коригиране."
 
-#: lib/merge.tcl:147
 #, tcl-format
 msgid "%s (%s): Merge"
 msgstr "%s (%s): Сливане"
 
-#: lib/merge.tcl:155
 #, tcl-format
 msgid "Merge Into %s"
 msgstr "Сливане в „%s“"
 
-#: lib/merge.tcl:174
 msgid "Revision To Merge"
 msgstr "Версия за сливане"
 
-#: lib/merge.tcl:209
 msgid ""
 "Cannot abort while amending.\n"
 "\n"
@@ -1900,7 +1498,6 @@ msgstr ""
 "\n"
 "Трябва да завършите поправката на това подаване.\n"
 
-#: lib/merge.tcl:219
 msgid ""
 "Abort merge?\n"
 "\n"
@@ -1914,7 +1511,6 @@ msgstr ""
 "\n"
 "Наистина ли да се преустанови сливането?"
 
-#: lib/merge.tcl:225
 msgid ""
 "Reset changes?\n"
 "\n"
@@ -1928,35 +1524,27 @@ msgstr ""
 "\n"
 "Наистина ли да се занулят промените?"
 
-#: lib/merge.tcl:237
 msgid "Aborting"
 msgstr "Преустановяване"
 
-#: lib/merge.tcl:238
 msgid "files reset"
 msgstr "файла със занулени промени"
 
-#: lib/merge.tcl:268
 msgid "Abort failed."
 msgstr "Неуспешно преустановяване."
 
-#: lib/merge.tcl:270
 msgid "Abort completed.  Ready."
 msgstr "Успешно преустановяване. Готовност за следващо действие."
 
-#: lib/mergetool.tcl:8
 msgid "Force resolution to the base version?"
 msgstr "Да се използва базовата версия"
 
-#: lib/mergetool.tcl:9
 msgid "Force resolution to this branch?"
 msgstr "Да се използва версията от този клон"
 
-#: lib/mergetool.tcl:10
 msgid "Force resolution to the other branch?"
 msgstr "Да се използва версията от другия клон"
 
-#: lib/mergetool.tcl:14
 #, tcl-format
 msgid ""
 "Note that the diff shows only conflicting changes.\n"
@@ -1971,34 +1559,28 @@ msgstr ""
 "\n"
 "Тази операция може да се отмени само чрез започване на сливането наново."
 
-#: lib/mergetool.tcl:45
 #, tcl-format
 msgid "File %s seems to have unresolved conflicts, still stage?"
 msgstr ""
 "Изглежда, че все още има некоригирани конфликти във файла „%s“. Да се добави "
 "ли файлът към индекса?"
 
-#: lib/mergetool.tcl:60
 #, tcl-format
 msgid "Adding resolution for %s"
 msgstr "Добавяне на корекция на конфликтите в „%s“"
 
-#: lib/mergetool.tcl:141
 msgid "Cannot resolve deletion or link conflicts using a tool"
 msgstr ""
 "Конфликтите при символни връзки или изтриване не може да се коригират с "
 "външна програма."
 
-#: lib/mergetool.tcl:146
 msgid "Conflict file does not exist"
 msgstr "Файлът, в който е конфликтът, не съществува"
 
-#: lib/mergetool.tcl:246
 #, tcl-format
 msgid "Not a GUI merge tool: '%s'"
 msgstr "Това не е графична програма за сливане: „%s“"
 
-#: lib/mergetool.tcl:278
 #, tcl-format
 msgid ""
 "Unable to process square brackets in \"mergetool.%s.cmd\" configuration "
@@ -2010,7 +1592,6 @@ msgstr ""
 "\n"
 "Махнете ги."
 
-#: lib/mergetool.tcl:289
 #, tcl-format
 msgid ""
 "Unsupported merge tool '%s'.\n"
@@ -2023,11 +1604,9 @@ msgstr ""
 "За да я използвате, настройте „mergetool.%s.cmd“ както както е обяснено в "
 "страницата на ръководството за „git-config“."
 
-#: lib/mergetool.tcl:327
 msgid "Merge tool is already running, terminate it?"
 msgstr "Програмата за сливане вече е стартирана. Да се изключи ли?"
 
-#: lib/mergetool.tcl:347
 #, tcl-format
 msgid ""
 "Error retrieving versions:\n"
@@ -2036,7 +1615,6 @@ msgstr ""
 "Грешка при изтеглянето на версии:\n"
 "%s"
 
-#: lib/mergetool.tcl:367
 #, tcl-format
 msgid ""
 "Could not start the merge tool:\n"
@@ -2047,277 +1625,211 @@ msgstr ""
 "\n"
 "%s"
 
-#: lib/mergetool.tcl:371
 msgid "Running merge tool..."
 msgstr "Стартиране на програмата за сливане…"
 
-#: lib/mergetool.tcl:399 lib/mergetool.tcl:407
 msgid "Merge tool failed."
 msgstr "Грешка в програмата за сливане."
 
-#: lib/option.tcl:11
 #, tcl-format
 msgid "Invalid global encoding '%s'"
 msgstr "Неправилно глобално кодиране „%s“"
 
-#: lib/option.tcl:19
 #, tcl-format
 msgid "Invalid repo encoding '%s'"
 msgstr "Неправилно кодиране „%s“ на хранилището"
 
-#: lib/option.tcl:119
 msgid "Restore Defaults"
 msgstr "Стандартни настройки"
 
-#: lib/option.tcl:123
 msgid "Save"
 msgstr "Запазване"
 
-#: lib/option.tcl:133
 #, tcl-format
 msgid "%s Repository"
 msgstr "Хранилище „%s“"
 
-#: lib/option.tcl:134
 msgid "Global (All Repositories)"
 msgstr "Глобално (за всички хранилища)"
 
-#: lib/option.tcl:140
 msgid "User Name"
 msgstr "Потребителско име"
 
-#: lib/option.tcl:141
 msgid "Email Address"
 msgstr "Адрес на е-поща"
 
-#: lib/option.tcl:143
 msgid "Summarize Merge Commits"
 msgstr "Обобщаване на подаванията при сливане"
 
-#: lib/option.tcl:144
 msgid "Merge Verbosity"
 msgstr "Подробности при сливанията"
 
-#: lib/option.tcl:145
 msgid "Show Diffstat After Merge"
 msgstr "Извеждане на статистика след сливанията"
 
-#: lib/option.tcl:146
 msgid "Use Merge Tool"
 msgstr "Използване на програма за сливане"
 
-#: lib/option.tcl:148
 msgid "Trust File Modification Timestamps"
 msgstr "Доверие във времето на промяна на файловете"
 
-#: lib/option.tcl:149
 msgid "Prune Tracking Branches During Fetch"
 msgstr "Окастряне на следящите клонове при доставяне"
 
-#: lib/option.tcl:150
 msgid "Match Tracking Branches"
 msgstr "Напасване на следящите клонове"
 
-#: lib/option.tcl:151
 msgid "Use Textconv For Diffs and Blames"
 msgstr "Използване на „textconv“ за разликите и анотирането"
 
-#: lib/option.tcl:152
 msgid "Blame Copy Only On Changed Files"
 msgstr "Анотиране на копието само по променените файлове"
 
-#: lib/option.tcl:153
 msgid "Maximum Length of Recent Repositories List"
 msgstr "Максимален брой на списъка „Скоро ползвани“ хранилища"
 
-#: lib/option.tcl:154
 msgid "Minimum Letters To Blame Copy On"
 msgstr "Минимален брой знаци за анотиране на копието"
 
-#: lib/option.tcl:155
 msgid "Blame History Context Radius (days)"
 msgstr "Исторически обхват за анотиране в дни"
 
-#: lib/option.tcl:156
 msgid "Number of Diff Context Lines"
 msgstr "Брой редове за контекста на разликите"
 
-#: lib/option.tcl:157
 msgid "Additional Diff Parameters"
 msgstr "Аргументи към командата за разликите"
 
-#: lib/option.tcl:158
 msgid "Commit Message Text Width"
 msgstr "Широчина на текста на съобщението при подаване"
 
-#: lib/option.tcl:159
 msgid "New Branch Name Template"
 msgstr "Шаблон за името на новите клони"
 
-#: lib/option.tcl:160
 msgid "Default File Contents Encoding"
 msgstr "Кодиране на файловете"
 
-#: lib/option.tcl:161
 msgid "Warn before committing to a detached head"
 msgstr "Предупреждаване при подаване към несвързан указател"
 
-#: lib/option.tcl:162
 msgid "Staging of untracked files"
 msgstr "Добавяне на неследените файлове към индекса"
 
-#: lib/option.tcl:163
 msgid "Show untracked files"
 msgstr "Показване на неследените файлове"
 
-#: lib/option.tcl:164
 msgid "Tab spacing"
 msgstr "Ширина на табулацията"
 
-#: lib/option.tcl:210
 msgid "Change"
 msgstr "Смяна"
 
-#: lib/option.tcl:248
 msgid "Spelling Dictionary:"
 msgstr "Правописен речник:"
 
-#: lib/option.tcl:272
 msgid "Change Font"
 msgstr "Смяна на шрифта"
 
-#: lib/option.tcl:276
 #, tcl-format
 msgid "Choose %s"
 msgstr "Избор на „%s“"
 
-#: lib/option.tcl:282
 msgid "pt."
 msgstr "тчк."
 
-#: lib/option.tcl:296
 msgid "Preferences"
 msgstr "Настройки"
 
-#: lib/option.tcl:333
 msgid "Failed to completely save options:"
 msgstr "Неуспешно запазване на настройките:"
 
-#: lib/remote_add.tcl:20
 #, tcl-format
 msgid "%s (%s): Add Remote"
 msgstr "%s (%s): Добавяне на отдалечено хранилище"
 
-#: lib/remote_add.tcl:25
 msgid "Add New Remote"
 msgstr "Добавяне на отдалечено хранилище"
 
-#: lib/remote_add.tcl:30 lib/tools_dlg.tcl:37
 msgid "Add"
 msgstr "Добавяне"
 
-#: lib/remote_add.tcl:39
 msgid "Remote Details"
 msgstr "Данни за отдалеченото хранилище"
 
-#: lib/remote_add.tcl:50
 msgid "Location:"
 msgstr "Местоположение:"
 
-#: lib/remote_add.tcl:60
 msgid "Further Action"
 msgstr "Следващо действие"
 
-#: lib/remote_add.tcl:63
 msgid "Fetch Immediately"
 msgstr "Незабавно доставяне"
 
-#: lib/remote_add.tcl:69
 msgid "Initialize Remote Repository and Push"
 msgstr "Инициализиране на отдалеченото хранилище и изтласкване на промените"
 
-#: lib/remote_add.tcl:75
 msgid "Do Nothing Else Now"
 msgstr "Да не се прави нищо"
 
-#: lib/remote_add.tcl:100
 msgid "Please supply a remote name."
 msgstr "Задайте име за отдалеченото хранилище."
 
-#: lib/remote_add.tcl:113
 #, tcl-format
 msgid "'%s' is not an acceptable remote name."
 msgstr "Отдалечено хранилище не може да се казва „%s“."
 
-#: lib/remote_add.tcl:124
 #, tcl-format
 msgid "Failed to add remote '%s' of location '%s'."
 msgstr "Неуспешно добавяне на отдалеченото хранилище „%s“ от адрес „%s“."
 
-#: lib/remote_add.tcl:132 lib/transport.tcl:6
 #, tcl-format
 msgid "fetch %s"
 msgstr "доставяне на „%s“"
 
-#: lib/remote_add.tcl:133
 #, tcl-format
 msgid "Fetching the %s"
 msgstr "Доставяне на „%s“"
 
-#: lib/remote_add.tcl:156
 #, tcl-format
 msgid "Do not know how to initialize repository at location '%s'."
 msgstr "Хранилището с местоположение „%s“ не може да се инициализира."
 
-#: lib/remote_add.tcl:162 lib/transport.tcl:54 lib/transport.tcl:92
-#: lib/transport.tcl:110
 #, tcl-format
 msgid "push %s"
 msgstr "изтласкване на „%s“"
 
-#: lib/remote_add.tcl:163
 #, tcl-format
 msgid "Setting up the %s (at %s)"
 msgstr "Добавяне на хранилище „%s“ (с адрес „%s“)"
 
-#: lib/remote_branch_delete.tcl:29
 #, tcl-format
 msgid "%s (%s): Delete Branch Remotely"
 msgstr "%s (%s): Изтриване на отдалечения клон"
 
-#: lib/remote_branch_delete.tcl:34
 msgid "Delete Branch Remotely"
 msgstr "Изтриване на отдалечения клон"
 
-#: lib/remote_branch_delete.tcl:48
 msgid "From Repository"
 msgstr "От хранилище"
 
-#: lib/remote_branch_delete.tcl:51 lib/transport.tcl:165
 msgid "Remote:"
 msgstr "Отдалечено хранилище:"
 
-#: lib/remote_branch_delete.tcl:68 lib/transport.tcl:183
 msgid "Arbitrary Location:"
 msgstr "Произволно местоположение:"
 
-#: lib/remote_branch_delete.tcl:84
 msgid "Branches"
 msgstr "Клони"
 
-#: lib/remote_branch_delete.tcl:106
 msgid "Delete Only If"
 msgstr "Изтриване, само ако"
 
-#: lib/remote_branch_delete.tcl:108
 msgid "Merged Into:"
 msgstr "Слят в:"
 
-#: lib/remote_branch_delete.tcl:149
 msgid "A branch is required for 'Merged Into'."
 msgstr "За данните „Слят в“ е необходимо да зададете клон."
 
-#: lib/remote_branch_delete.tcl:181
 #, tcl-format
 msgid ""
 "The following branches are not completely merged into %s:\n"
@@ -2328,7 +1840,6 @@ msgstr ""
 "\n"
 " ● %s"
 
-#: lib/remote_branch_delete.tcl:186
 #, tcl-format
 msgid ""
 "One or more of the merge tests failed because you have not fetched the "
@@ -2337,140 +1848,107 @@ msgstr ""
 "Поне една от пробите за сливане е неуспешна, защото не сте доставили всички "
 "необходими подавания. Пробвайте първо да доставите подаванията от „%s“."
 
-#: lib/remote_branch_delete.tcl:204
 msgid "Please select one or more branches to delete."
 msgstr "Изберете поне един клон за изтриване."
 
-#: lib/remote_branch_delete.tcl:223
 #, tcl-format
 msgid "Deleting branches from %s"
 msgstr "Изтриване на клони от „%s“"
 
-#: lib/remote_branch_delete.tcl:296
 msgid "No repository selected."
 msgstr "Не е избрано хранилище."
 
-#: lib/remote_branch_delete.tcl:301
 #, tcl-format
 msgid "Scanning %s..."
 msgstr "Претърсване на „%s“…"
 
-#: lib/remote.tcl:200
 msgid "Push to"
 msgstr "Изтласкване към"
 
-#: lib/remote.tcl:218
 msgid "Remove Remote"
 msgstr "Премахване на отдалечено хранилище"
 
-#: lib/remote.tcl:223
 msgid "Prune from"
 msgstr "Окастряне от"
 
-#: lib/remote.tcl:228
 msgid "Fetch from"
 msgstr "Доставяне от"
 
-#: lib/remote.tcl:247 lib/remote.tcl:251 lib/remote.tcl:256 lib/remote.tcl:262
 msgid "All"
 msgstr "Всички"
 
-#: lib/search.tcl:47
 msgid "Find:"
 msgstr "Търсене:"
 
-#: lib/search.tcl:49
 msgid "Next"
 msgstr "Следваща поява"
 
-#: lib/search.tcl:50
 msgid "Prev"
 msgstr "Предишна поява"
 
-#: lib/search.tcl:51
 msgid "RegExp"
 msgstr "РегИзр"
 
-#: lib/search.tcl:53
 msgid "Case"
 msgstr "Главни/Малки"
 
-#: lib/shortcut.tcl:8 lib/shortcut.tcl:40 lib/shortcut.tcl:72
 #, tcl-format
 msgid "%s (%s): Create Desktop Icon"
 msgstr "%s (%s): Добавяне на икона на работния плот"
 
-#: lib/shortcut.tcl:24 lib/shortcut.tcl:62
 msgid "Cannot write shortcut:"
 msgstr "Клавишната комбинация не може да се запази:"
 
-#: lib/shortcut.tcl:137
 msgid "Cannot write icon:"
 msgstr "Иконата не може да се запази:"
 
-#: lib/spellcheck.tcl:57
 msgid "Unsupported spell checker"
 msgstr "Тази програма за проверка на правописа не се поддържа"
 
-#: lib/spellcheck.tcl:65
 msgid "Spell checking is unavailable"
 msgstr "Липсва програма за проверка на правописа"
 
-#: lib/spellcheck.tcl:68
 msgid "Invalid spell checking configuration"
 msgstr "Неправилни настройки на проверката на правописа"
 
-#: lib/spellcheck.tcl:70
 #, tcl-format
 msgid "Reverting dictionary to %s."
 msgstr "Ползване на речник за език „%s“."
 
-#: lib/spellcheck.tcl:73
 msgid "Spell checker silently failed on startup"
 msgstr "Програмата за правопис даже не стартира успешно."
 
-#: lib/spellcheck.tcl:80
 msgid "Unrecognized spell checker"
 msgstr "Непозната програма за проверка на правописа"
 
-#: lib/spellcheck.tcl:186
 msgid "No Suggestions"
 msgstr "Няма предложения"
 
-#: lib/spellcheck.tcl:388
 msgid "Unexpected EOF from spell checker"
 msgstr "Неочакван край на файл от програмата за проверка на правописа"
 
-#: lib/spellcheck.tcl:392
 msgid "Spell Checker Failed"
 msgstr "Грешка в програмата за проверка на правописа"
 
-#: lib/sshkey.tcl:34
 msgid "No keys found."
 msgstr "Не са открити ключове."
 
-#: lib/sshkey.tcl:37
 #, tcl-format
 msgid "Found a public key in: %s"
 msgstr "Открит е публичен ключ в „%s“"
 
-#: lib/sshkey.tcl:43
 msgid "Generate Key"
 msgstr "Генериране на ключ"
 
-#: lib/sshkey.tcl:58
 msgid "Copy To Clipboard"
 msgstr "Копиране към системния буфер"
 
-#: lib/sshkey.tcl:72
 msgid "Your OpenSSH Public Key"
 msgstr "Публичният ви ключ за OpenSSH"
 
-#: lib/sshkey.tcl:80
 msgid "Generating..."
 msgstr "Генериране…"
 
-#: lib/sshkey.tcl:87
 #, tcl-format
 msgid ""
 "Could not start ssh-keygen:\n"
@@ -2481,81 +1959,63 @@ msgstr ""
 "\n"
 "%s"
 
-#: lib/sshkey.tcl:114
 msgid "Generation failed."
 msgstr "Неуспешно генериране."
 
-#: lib/sshkey.tcl:121
 msgid "Generation succeeded, but no keys found."
 msgstr "Генерирането завърши успешно, а не са намерени ключове."
 
-#: lib/sshkey.tcl:124
 #, tcl-format
 msgid "Your key is in: %s"
 msgstr "Ключът ви е в „%s“"
 
-#: lib/status_bar.tcl:258
 #, tcl-format
 msgid "%s ... %*i of %*i %s (%3i%%)"
 msgstr "%s… %*i от общо %*i %s (%3i%%)"
 
-#: lib/tools_dlg.tcl:22
 #, tcl-format
 msgid "%s (%s): Add Tool"
 msgstr "%s (%s): Добавяне на команда"
 
-#: lib/tools_dlg.tcl:28
 msgid "Add New Tool Command"
 msgstr "Добавяне на команда"
 
-#: lib/tools_dlg.tcl:34
 msgid "Add globally"
 msgstr "Глобално добавяне"
 
-#: lib/tools_dlg.tcl:46
 msgid "Tool Details"
 msgstr "Подробности за командата"
 
-#: lib/tools_dlg.tcl:49
 msgid "Use '/' separators to create a submenu tree:"
 msgstr "За създаване на подменюта използвайте знака „/“ за разделител:"
 
-#: lib/tools_dlg.tcl:60
 msgid "Command:"
 msgstr "Команда:"
 
-#: lib/tools_dlg.tcl:71
 msgid "Show a dialog before running"
 msgstr "Преди изпълнение да се извежда диалогов прозорец"
 
-#: lib/tools_dlg.tcl:77
 msgid "Ask the user to select a revision (sets $REVISION)"
 msgstr "Потребителят да укаже версия (задаване на променливата $REVISION)"
 
-#: lib/tools_dlg.tcl:82
 msgid "Ask the user for additional arguments (sets $ARGS)"
 msgstr ""
 "Потребителят да укаже допълнителни аргументи (задаване на променливата $ARGS)"
 
-#: lib/tools_dlg.tcl:89
 msgid "Don't show the command output window"
 msgstr "Без показване на прозорец с изхода от командата"
 
-#: lib/tools_dlg.tcl:94
 msgid "Run only if a diff is selected ($FILENAME not empty)"
 msgstr ""
 "Стартиране само след избор на разлика (променливата $FILENAME не е празна)"
 
-#: lib/tools_dlg.tcl:118
 msgid "Please supply a name for the tool."
 msgstr "Задайте име за командата."
 
-#: lib/tools_dlg.tcl:126
 #, tcl-format
 msgid "Tool '%s' already exists."
 msgstr "Командата „%s“ вече съществува."
 
-#: lib/tools_dlg.tcl:148
 #, tcl-format
 msgid ""
 "Could not add tool:\n"
@@ -2564,154 +2024,121 @@ msgstr ""
 "Командата не може да се добави:\n"
 "%s"
 
-#: lib/tools_dlg.tcl:187
 #, tcl-format
 msgid "%s (%s): Remove Tool"
 msgstr "%s (%s): Премахване на команда"
 
-#: lib/tools_dlg.tcl:193
 msgid "Remove Tool Commands"
 msgstr "Премахване на команди"
 
-#: lib/tools_dlg.tcl:198
 msgid "Remove"
 msgstr "Премахване"
 
-#: lib/tools_dlg.tcl:231
 msgid "(Blue denotes repository-local tools)"
 msgstr "(командите към локалното хранилище са обозначени в синьо)"
 
-#: lib/tools_dlg.tcl:283
 #, tcl-format
 msgid "%s (%s):"
 msgstr "%s (%s):"
 
-#: lib/tools_dlg.tcl:292
 #, tcl-format
 msgid "Run Command: %s"
 msgstr "Изпълнение на командата „%s“"
 
-#: lib/tools_dlg.tcl:306
 msgid "Arguments"
 msgstr "Аргументи"
 
-#: lib/tools_dlg.tcl:341
 msgid "OK"
 msgstr "Добре"
 
-#: lib/tools.tcl:76
 #, tcl-format
 msgid "Running %s requires a selected file."
 msgstr "За изпълнението на „%s“ трябва да изберете файл."
 
-#: lib/tools.tcl:92
 #, tcl-format
 msgid "Are you sure you want to run %1$s on file \"%2$s\"?"
 msgstr "Сигурни ли сте, че искате да изпълните „%1$s“ върху файла „%2$s“?"
 
-#: lib/tools.tcl:96
 #, tcl-format
 msgid "Are you sure you want to run %s?"
 msgstr "Сигурни ли сте, че искате да изпълните „%s“?"
 
-#: lib/tools.tcl:118
 #, tcl-format
 msgid "Tool: %s"
 msgstr "Команда: %s"
 
-#: lib/tools.tcl:119
 #, tcl-format
 msgid "Running: %s"
 msgstr "Изпълнение: %s"
 
-#: lib/tools.tcl:157
 #, tcl-format
 msgid "Tool completed successfully: %s"
 msgstr "Командата завърши успешно: %s"
 
-#: lib/tools.tcl:159
 #, tcl-format
 msgid "Tool failed: %s"
 msgstr "Командата върна грешка: %s"
 
-#: lib/transport.tcl:7
 #, tcl-format
 msgid "Fetching new changes from %s"
 msgstr "Доставяне на промените от „%s“"
 
-#: lib/transport.tcl:18
 #, tcl-format
 msgid "remote prune %s"
 msgstr "окастряне на следящите клони към „%s“"
 
-#: lib/transport.tcl:19
 #, tcl-format
 msgid "Pruning tracking branches deleted from %s"
 msgstr "Окастряне на следящите клони на изтритите клони от „%s“"
 
-#: lib/transport.tcl:25
 msgid "fetch all remotes"
 msgstr "доставяне от всички отдалечени"
 
-#: lib/transport.tcl:26
 msgid "Fetching new changes from all remotes"
 msgstr "Доставяне на промените от всички отдалечени хранилища"
 
-#: lib/transport.tcl:40
 msgid "remote prune all remotes"
 msgstr "окастряне на следящите изтрити"
 
-#: lib/transport.tcl:41
 msgid "Pruning tracking branches deleted from all remotes"
 msgstr ""
 "Окастряне на следящите клони на изтритите клони от всички отдалечени "
 "хранилища"
 
-#: lib/transport.tcl:55
 #, tcl-format
 msgid "Pushing changes to %s"
 msgstr "Изтласкване на промените към „%s“"
 
-#: lib/transport.tcl:93
 #, tcl-format
 msgid "Mirroring to %s"
 msgstr "Изтласкване на всичко към „%s“"
 
-#: lib/transport.tcl:111
 #, tcl-format
 msgid "Pushing %s %s to %s"
 msgstr "Изтласкване на %s „%s“ към „%s“"
 
-#: lib/transport.tcl:132
 msgid "Push Branches"
 msgstr "Клони за изтласкване"
 
-#: lib/transport.tcl:147
 msgid "Source Branches"
 msgstr "Клони-източници"
 
-#: lib/transport.tcl:162
 msgid "Destination Repository"
 msgstr "Целево хранилище"
 
-#: lib/transport.tcl:201
 msgid "Transfer Options"
 msgstr "Настройки при пренасянето"
 
-#: lib/transport.tcl:203
 msgid "Force overwrite existing branch (may discard changes)"
 msgstr ""
 "Изрично презаписване на съществуващ клон (някои промени може да се загубят)"
 
-#: lib/transport.tcl:207
 msgid "Use thin pack (for slow network connections)"
 msgstr "Максимална компресия (за бавни мрежови връзки)"
 
-#: lib/transport.tcl:211
 msgid "Include tags"
 msgstr "Включване на етикетите"
 
-#: lib/transport.tcl:225
 #, tcl-format
 msgid "%s (%s): Push"
 msgstr "%s (%s): Изтласкване"


### PR DESCRIPTION
Remove the location of messages to ease sending diffs via mail list.
This brings the po-file in line with git po-file.