### PR TITLE
gitk: use <Button-3> for ctx menus on macOS with Tcl 8.7+

### DIFF
--- a/gitk
+++ b/gitk
@@ -12596,7 +12596,7 @@ set foundbgcolor yellow
 set currentsearchhitbgcolor orange
 
 # button for popping up context menus
-if {[tk windowingsystem] eq "aqua"} {
+if {[tk windowingsystem] eq "aqua" && [package vcompare $::tcl_version 8.7] < 0} {
     set ctxbut <Button-2>
 } else {
     set ctxbut <Button-3>


### PR DESCRIPTION
Commit d277e89f87fda01daa1e1a35fc1f7118678faa1f added special handling on macOS (OS X) that makes button 2 the right mouse button. As per TIP 474 [^1], Tcl 8.7 has swapped buttons 2 and 3 such that button 3 is made the right mouse button as in other platforms. Therefore, the logic should be updated to use button 3 on macOS with Tcl 8.7+.

[^1]: https://core.tcl-lang.org/tips/doc/main/tip/474.md
