### PR TITLE
improve gitk use of themes

### DIFF
--- a/gitk
+++ b/gitk
@@ -11894,6 +11894,10 @@ proc doprefs {} {
     grid $top.buts.ok $top.buts.can -padx 20
     grid $top.buts -sticky w -pady 10
     bind $top <Visibility> [list focus $top.buts.ok]
+
+    # let geometry manager determine run, set minimum size
+    update idletasks
+    wm minsize $top [winfo reqwidth $top] [winfo reqheight $top]
 }
 
 proc choose_extdiff {} {


### PR DESCRIPTION
This is addressing #33, and updates gitk to more fully implement themes. Two new configuration variables are added:
* theme          - this is the name of the theme to use (clam, alt, classic, default, ...)
* themeloader - this is the full pathname of a tcl script that when sourced defines one or more themes to be added.

I find some good dark mode themes in the awthemes-10.4.0.zip file available at [tcl-awthemes](https://sourceforge.net/projects/tcl-awthemes/), but most of the themes in that package require Tcl 9.0 (or some additional packages for Tcl 8.6). 

For instance, unzip the above file in /tmp, then edit gitk's config file to have

`set themeloader /tmp/awthemes-10.4.0/awdark.tcl`
`set theme awdark`

This is a good dark mode and works under Tcl 8.6 and Tcl 9.0. Colors must be adjusted in the config file to handle the canvas  objects (foreground and background colors at least).

There is an option in the config page (on the colors page) to select among the installed themes as well.