### PR TITLE
gitk: fix msgfmt being required

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -25,6 +25,6 @@ custom_target(
   install_dir: get_option('bindir'),
 )
 
-if find_program('msgfmt').found()
+if find_program('msgfmt', required: false).found()
   subdir('po')
 endif


### PR DESCRIPTION
While the Meson build instructions already handle the case where msgfmt wasn't found, we forgot to mark the dependency itself as optional. This causes an error in case the executable could not be found:

  Project name: gitk
  Project version: undefined
  Program sh found: YES (C:\Program Files\Git\bin\sh.EXE)
  Program wish found: YES (C:\Program Files\Git\mingw64\bin\wish.EXE)
  Program chmod found: YES (C:\Program Files\Git\usr\bin\chmod.EXE)
  Program mv found: YES (C:\Program Files\Git\usr\bin\mv.EXE)
  Program sed found: YES (C:\Program Files\Git\usr\bin\sed.EXE)
  Program msgfmt found: NO

  subprojects\gitk\meson.build:28:3: ERROR: Program 'msgfmt' not found or not executable

Fix the issue by adding the `required: false` parameter.