### PR TITLE
Fix l10n package names and ignore generated POT file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /GIT-TCLTK-VARS
 /gitk-wish
+po/gitk.pot

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ gitk-wish: gitk GIT-TCLTK-VARS
 	$(SHELL_PATH) ./generate-tcl.sh "$(TCLTK_PATH_SQ)" "$<" "$@"
 
 $(PO_TEMPLATE): gitk
-	$(XGETTEXT) -kmc -LTcl -o $@ gitk
+	$(XGETTEXT) -kmc -LTcl --package-name=Gitk -o $@ gitk
 update-po:: $(PO_TEMPLATE)
 	$(foreach p, $(ALL_POFILES), echo Updating $p ; msgmerge -U $p $(PO_TEMPLATE) ; )
 $(ALL_MSGFILES): %.msg : %.po

--- a/po/bg.po
+++ b/po/bg.po
@@ -6,7 +6,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: gitk master\n"
+"Project-Id-Version: Gitk master\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-07-22 18:34+0200\n"
 "PO-Revision-Date: 2025-07-28 13:38+0200\n"

--- a/po/ca.po
+++ b/po/ca.po
@@ -6,7 +6,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: gitk\n"
+"Project-Id-Version: Gitk\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2015-05-17 14:32+1000\n"
 "PO-Revision-Date: 2015-10-05 22:23-0600\n"

--- a/po/de.po
+++ b/po/de.po
@@ -6,7 +6,7 @@
 # Frederik Schwarzer <schwarzerf@gmail.com>, 2008.
 msgid ""
 msgstr ""
-"Project-Id-Version: git-gui\n"
+"Project-Id-Version: Gitk\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2015-05-17 14:32+1000\n"
 "PO-Revision-Date: 2015-10-20 14:20+0200\n"

--- a/po/es.po
+++ b/po/es.po
@@ -6,7 +6,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: gitk\n"
+"Project-Id-Version: Gitk\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2015-05-17 14:32+1000\n"
 "PO-Revision-Date: 2008-03-25 11:20+0100\n"

--- a/po/fr.po
+++ b/po/fr.po
@@ -6,7 +6,7 @@
 # Jean-Noël Avila <jn.avila@free.fr>
 msgid ""
 msgstr ""
-"Project-Id-Version: gitk\n"
+"Project-Id-Version: Gitk\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-01-22 22:04+0100\n"
 "PO-Revision-Date: 2016-01-22 23:28+0100\n"

--- a/po/hu.po
+++ b/po/hu.po
@@ -6,7 +6,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: git-gui\n"
+"Project-Id-Version: Gitk\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2015-05-17 14:32+1000\n"
 "PO-Revision-Date: 2009-12-14 14:04+0100\n"

--- a/po/it.po
+++ b/po/it.po
@@ -6,7 +6,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: gitk\n"
+"Project-Id-Version: Gitk\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2015-05-17 14:32+1000\n"
 "PO-Revision-Date: 2010-01-28 18:41+0100\n"

--- a/po/ja.po
+++ b/po/ja.po
@@ -8,7 +8,7 @@
 # Satoshi Yasushima <s.yasushima@gmail.com>, 2016.
 msgid ""
 msgstr ""
-"Project-Id-Version: gitk\n"
+"Project-Id-Version: Gitk\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2015-05-17 14:32+1000\n"
 "PO-Revision-Date: 2015-11-12 13:00+0900\n"

--- a/po/pt_br.po
+++ b/po/pt_br.po
@@ -7,7 +7,7 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: gitk\n"
+"Project-Id-Version: Gitk\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2015-05-17 14:32+1000\n"
 "PO-Revision-Date: 2010-12-06 23:39-0200\n"

--- a/po/pt_pt.po
+++ b/po/pt_pt.po
@@ -4,7 +4,7 @@
 # Vasco Almeida <vascomalmeida@sapo.pt>, 2016.
 msgid ""
 msgstr ""
-"Project-Id-Version: gitk\n"
+"Project-Id-Version: Gitk\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-04-15 16:52+0000\n"
 "PO-Revision-Date: 2016-05-06 15:35+0000\n"

--- a/po/ru.po
+++ b/po/ru.po
@@ -8,7 +8,7 @@
 # Skip <bsvskip@rambler.ru>, 2011
 msgid ""
 msgstr ""
-"Project-Id-Version: Git Russian Localization Project\n"
+"Project-Id-Version: Gitk Russian Localization Project\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-12-15 00:18+0200\n"
 "PO-Revision-Date: 2016-12-14 22:23+0000\n"

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: sv\n"
+"Project-Id-Version: Gitk\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2023-10-26 21:39+0100\n"
 "PO-Revision-Date: 2023-10-26 21:42+0100\n"

--- a/po/ta.po
+++ b/po/ta.po
@@ -6,7 +6,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: gitk\n"
+"Project-Id-Version: Gitk\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-05-07 08:01+0530\n"
 "PO-Revision-Date: 2025-05-07 09:17\n"

--- a/po/vi.po
+++ b/po/vi.po
@@ -5,7 +5,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: gitk @@GIT_VERSION@@\n"
+"Project-Id-Version: Gitk @@GIT_VERSION@@\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2015-05-17 14:32+1000\n"
 "PO-Revision-Date: 2015-09-15 07:33+0700\n"

--- a/po/zh_cn.po
+++ b/po/zh_cn.po
@@ -5,7 +5,7 @@
 
 msgid ""
 msgstr ""
-"Project-Id-Version: Git Chinese Localization Project\n"
+"Project-Id-Version: Gitk Chinese Localization Project\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2017-02-28 23:11+0800\n"
 "PO-Revision-Date: 2017-03-11 02:27+0800\n"


### PR DESCRIPTION
This PR addresses l10n-related issues with package names in translation files and improves the gitignore configuration:

- Fixed the package name in PO file headers to ensure proper l10n metadata
- Updated the POT file to use "Gitk" as the correct package name for i18n
- Added generated POT files to .gitignore to prevent them from being tracked in the repository

These changes ensure consistent package naming in l10n files and cleaner repository state by ignoring generated translation template file.