### PR TITLE
gitk: add horizontal scrollbar to the commit list pane

### DIFF
--- a/gitk
+++ b/gitk
@@ -2469,7 +2469,8 @@ proc makewindow {} {
         -selectbackground $selectbgcolor \
         -background $bgcolor -bd 0 \
         -xscrollincr $linespc \
-        -yscrollincr $linespc -yscrollcommand "scrollcanv $cscroll"
+        -yscrollincr $linespc -yscrollcommand "scrollcanv $cscroll" \
+        -xscrollcommand ".tf.histframe.cxsb set"
     .tf.histframe.pwclist add $canv
     set canv2 .tf.histframe.pwclist.canv2
     canvas $canv2 \
@@ -2487,9 +2488,11 @@ proc makewindow {} {
         .tf.histframe.pwclist sashpos 0 [lindex $::geometry(pwsash0) 0]
     }
 
-    # a scroll bar to rule them
+    # a scroll bar to rule them (vertical), and one for horizontal scroll of left pane
     ttk::scrollbar $cscroll -command {allcanvs yview}
     pack $cscroll -side right -fill y
+    ttk::scrollbar .tf.histframe.cxsb -orient horizontal -command "$canv xview"
+    pack .tf.histframe.cxsb -side bottom -fill x
     bind .tf.histframe.pwclist <Configure> {resizeclistpanes %W %w}
     lappend bglist $canv $canv2 $canv3
     pack .tf.histframe.pwclist -fill both -expand 1 -side left


### PR DESCRIPTION
I am not fluent in Tcl/Tk.  However, the lack of a horizontal scrollbar in the commit pane of gitk has frustrated me for years.  So this morning I took to Claude to rectify it.


When many branches and tags decorate the same commit, the ref labels push the commit description far to the right, often out of the visible area of the left pane.  The canvas widget already tracked the maximum x extent via canvxmax and updated its scrollregion accordingly, but there was no scrollbar wired up to let the user reach that content.

Add a horizontal scrollbar (.tf.histframe.cxsb) below the three-pane history area, connected to the left canvas (canv) via its xscrollcommand and xview.  Switch the .tf.histframe children from pack to a grid layout so the new scrollbar occupies its own row beneath the paned window while the existing vertical scrollbar retains its position to the right.  The scrollbar spans the full width of the paned window area, which matches the natural expectation that it scrolls the history pane.

No behaviour is changed for the author (canv2) or date (canv3) panes; they continue to scroll only vertically in lock-step as before.