### PR TITLE
Make color preferences visually more pleasing and better usable

### DIFF
--- a/gitk
+++ b/gitk
@@ -11832,55 +11832,46 @@ proc prefspage_colors {notebook} {
 
     ttk::label $page.cdisp -text [mc "Colors: press to choose"] -font mainfontbold
     grid $page.cdisp - -sticky w -pady 10
-    label $page.bg -padx 40 -relief sunk
-    ttk::button $page.bgbut -text [mc "Background"] \
-        -command [list choosecolor bgcolor {} $page [mc "background"]]
-    grid x $page.bgbut $page.bg -sticky w
 
-    label $page.fg -padx 40 -relief sunk
-    ttk::button $page.fgbut -text [mc "Foreground"] \
-        -command [list choosecolor fgcolor {} $page [mc "foreground"]]
-    grid x $page.fgbut $page.fg -sticky w
+    set coloruielems [list \
+        bg          bgcolor {} \
+                    [mc "Background"] \
+                    [mc "background"] \
+        fg          fgcolor {} \
+                    [mc "Foreground"] \
+                    [mc "foreground"] \
+        diffold     diffcolors 0 \
+                    [mc "Diff: old lines"] \
+                    [mc "diff old lines"] \
+        diffoldbg   diffbgcolors 0 \
+                    [mc "Diff: old lines bg"] \
+                    [mc "diff old lines bg"] \
+        diffnew     diffcolors 1 \
+                    [mc "Diff: new lines"] \
+                    [mc "diff new lines"] \
+        diffnewbg   diffbgcolors 1 \
+                    [mc "Diff: new lines bg"] \
+                    [mc "diff new lines bg"] \
+        hunksep     diffcolors 2 \
+                    [mc "Diff: hunk header"] \
+                    [mc "diff hunk header"] \
+        markbg      markbgcolor {} \
+                    [mc "Marked line bg"] \
+                    [mc "marked line background"] \
+        selbg       selectbgcolor {} \
+                    [mc "Select bg"] \
+                    [mc "background"] \
+        linkfg      linkfgcolor {} \
+                    [mc "Link"] \
+                    [mc "link"] \
+    ]
 
-    label $page.diffold -padx 40 -relief sunk
-    ttk::button $page.diffoldbut -text [mc "Diff: old lines"] \
-        -command [list choosecolor diffcolors 0 $page [mc "diff old lines"]]
-    grid x $page.diffoldbut $page.diffold -sticky w
-
-    label $page.diffoldbg -padx 40 -relief sunk
-    ttk::button $page.diffoldbgbut -text [mc "Diff: old lines bg"] \
-        -command [list choosecolor diffbgcolors 0 $page [mc "diff old lines bg"]]
-    grid x $page.diffoldbgbut $page.diffoldbg -sticky w
-
-    label $page.diffnew -padx 40 -relief sunk
-    ttk::button $page.diffnewbut -text [mc "Diff: new lines"] \
-        -command [list choosecolor diffcolors 1 $page [mc "diff new lines"]]
-    grid x $page.diffnewbut $page.diffnew -sticky w
-
-    label $page.diffnewbg -padx 40 -relief sunk
-    ttk::button $page.diffnewbgbut -text [mc "Diff: new lines bg"] \
-        -command [list choosecolor diffbgcolors 1 $page [mc "diff new lines bg"]]
-    grid x $page.diffnewbgbut $page.diffnewbg -sticky w
-
-    label $page.hunksep -padx 40 -relief sunk
-    ttk::button $page.hunksepbut -text [mc "Diff: hunk header"] \
-        -command [list choosecolor diffcolors 2 $page [mc "diff hunk header"]]
-    grid x $page.hunksepbut $page.hunksep -sticky w
-
-    label $page.markbgsep -padx 40 -relief sunk
-    ttk::button $page.markbgbut -text [mc "Marked line bg"] \
-        -command [list choosecolor markbgcolor {} $page [mc "marked line background"]]
-    grid x $page.markbgbut $page.markbgsep -sticky w
-
-    label $page.selbgsep -padx 40 -relief sunk
-    ttk::button $page.selbgbut -text [mc "Select bg"] \
-        -command [list choosecolor selectbgcolor {} $page [mc "background"]]
-    grid x $page.selbgbut $page.selbgsep -sticky w
-
-    label $page.linkfg -padx 40 -relief sunk
-    ttk::button $page.linkfgbut -text [mc "Link"] \
-        -command [list choosecolor linkfgcolor {} $page [mc "link"]]
-    grid x $page.linkfgbut $page.linkfg -sticky w
+    foreach {uielem colorvar idx label title} $coloruielems {
+        label $page.$uielem -padx 40 -relief sunk
+        ttk::button $page.${uielem}btn -text $label \
+            -command [list choosecolor $colorvar $idx $page $title]
+        grid x $page.${uielem}btn $page.$uielem -sticky w
+    }
 
     grid columnconfigure $page 2 -weight 1
     prefspage_set_colorswatches $page
@@ -11892,16 +11883,21 @@ proc prefspage_set_colorswatches {page} {
     global bgcolor fgcolor diffcolors selectbgcolor markbgcolor
     global diffbgcolors linkfgcolor
 
-    $page.bg configure -background $bgcolor
-    $page.fg configure -background $fgcolor
-    $page.diffold configure -background [lindex $diffcolors 0]
-    $page.diffoldbg configure -background [lindex $diffbgcolors 0]
-    $page.diffnew configure -background [lindex $diffcolors 1]
-    $page.diffnewbg configure -background [lindex $diffbgcolors 1]
-    $page.hunksep configure -background [lindex $diffcolors 2]
-    $page.markbgsep configure -background $markbgcolor
-    $page.selbgsep configure -background $selectbgcolor
-    $page.linkfg configure -background $linkfgcolor
+    set coloruielems [list \
+        bg        $bgcolor \
+        fg        $fgcolor \
+        diffold   [lindex $diffcolors 0] \
+        diffoldbg [lindex $diffbgcolors 0] \
+        diffnew   [lindex $diffcolors 1] \
+        diffnewbg [lindex $diffbgcolors 1] \
+        hunksep   [lindex $diffcolors 2] \
+        markbg    $markbgcolor \
+        selbg     $selectbgcolor \
+        linkfg    $linkfgcolor \
+    ]
+    foreach {uielem color} $coloruielems {
+        $page.$uielem configure -background $color
+    }
 }
 
 proc prefspage_fonts {notebook} {

--- a/gitk
+++ b/gitk
@@ -11836,34 +11836,34 @@ proc prefspage_colors {notebook} {
     set coloruielems [list \
         bg          bgcolor {} \
                     [mc "Background"] \
-                    [mc "background"] \
+                    [mc "choose background color"] \
         fg          fgcolor {} \
                     [mc "Main text"] \
-                    [mc "foreground"] \
+                    [mc "choose main text color"] \
         diffold     diffcolors 0 \
                     [mc "Old line text"] \
-                    [mc "diff old lines"] \
+                    [mc "choose text color of old lines"] \
         diffoldbg   diffbgcolors 0 \
                     [mc "Old line background"] \
-                    [mc "diff old lines bg"] \
+                    [mc "choose background color of old lines"] \
         diffnew     diffcolors 1 \
                     [mc "New line text"] \
-                    [mc "diff new lines"] \
+                    [mc "choose text color of new lines"] \
         diffnewbg   diffbgcolors 1 \
                     [mc "New line background"] \
-                    [mc "diff new lines bg"] \
+                    [mc "choose background color of new lines"] \
         hunksep     diffcolors 2 \
                     [mc "Hunk header text"] \
-                    [mc "diff hunk header"] \
+                    [mc "choose text color of hunk headers"] \
         markbg      markbgcolor {} \
                     [mc "Marked line background"] \
-                    [mc "marked line background"] \
+                    [mc "choose background color of marked lines"] \
         selbg       selectbgcolor {} \
                     [mc "Selected text background"] \
-                    [mc "background"] \
+                    [mc "choose background color of selected text"] \
         linkfg      linkfgcolor {} \
                     [mc "Link text"] \
-                    [mc "link"] \
+                    [mc "choose color of link text"] \
     ]
 
     foreach {uielem colorvar idx label title} $coloruielems {
@@ -12014,11 +12014,11 @@ proc choose_themeloader {prefspage} {
     }
 }
 
-proc choosecolor {v vi prefspage x} {
+proc choosecolor {v vi prefspage title} {
     global $v
 
     set c [tk_chooseColor -initialcolor [lindex [set $v] $vi] \
-               -title [mc "Gitk: choose color for %s" $x]]
+               -title "Gitk: $title"]
     if {$c eq {}} return
     lset $v $vi $c
     set_gui_colors

--- a/gitk
+++ b/gitk
@@ -11840,6 +11840,12 @@ proc prefspage_colors {notebook} {
         fg          fgcolor {} \
                     [mc "Main text"] \
                     [mc "choose main text color"] \
+        selbg       selectbgcolor {} \
+                    [mc "Selected text background"] \
+                    [mc "choose background color of selected text"] \
+        linkfg      linkfgcolor {} \
+                    [mc "Link text"] \
+                    [mc "choose color of link text"] \
         diffold     diffcolors 0 \
                     [mc "Old line text"] \
                     [mc "choose text color of old lines"] \
@@ -11858,12 +11864,6 @@ proc prefspage_colors {notebook} {
         markbg      markbgcolor {} \
                     [mc "Marked line background"] \
                     [mc "choose background color of marked lines"] \
-        selbg       selectbgcolor {} \
-                    [mc "Selected text background"] \
-                    [mc "choose background color of selected text"] \
-        linkfg      linkfgcolor {} \
-                    [mc "Link text"] \
-                    [mc "choose color of link text"] \
     ]
 
     foreach {uielem colorvar idx label title} $coloruielems {

--- a/gitk
+++ b/gitk
@@ -11838,31 +11838,31 @@ proc prefspage_colors {notebook} {
                     [mc "Background"] \
                     [mc "background"] \
         fg          fgcolor {} \
-                    [mc "Foreground"] \
+                    [mc "Main text"] \
                     [mc "foreground"] \
         diffold     diffcolors 0 \
-                    [mc "Diff: old lines"] \
+                    [mc "Old line text"] \
                     [mc "diff old lines"] \
         diffoldbg   diffbgcolors 0 \
-                    [mc "Diff: old lines bg"] \
+                    [mc "Old line background"] \
                     [mc "diff old lines bg"] \
         diffnew     diffcolors 1 \
-                    [mc "Diff: new lines"] \
+                    [mc "New line text"] \
                     [mc "diff new lines"] \
         diffnewbg   diffbgcolors 1 \
-                    [mc "Diff: new lines bg"] \
+                    [mc "New line background"] \
                     [mc "diff new lines bg"] \
         hunksep     diffcolors 2 \
-                    [mc "Diff: hunk header"] \
+                    [mc "Hunk header text"] \
                     [mc "diff hunk header"] \
         markbg      markbgcolor {} \
-                    [mc "Marked line bg"] \
+                    [mc "Marked line background"] \
                     [mc "marked line background"] \
         selbg       selectbgcolor {} \
-                    [mc "Select bg"] \
+                    [mc "Selected text background"] \
                     [mc "background"] \
         linkfg      linkfgcolor {} \
-                    [mc "Link"] \
+                    [mc "Link text"] \
                     [mc "link"] \
     ]
 

--- a/gitk
+++ b/gitk
@@ -11867,10 +11867,10 @@ proc prefspage_colors {notebook} {
     ]
 
     foreach {uielem colorvar idx label title} $coloruielems {
-        label $page.$uielem -padx 40 -relief sunk
-        ttk::button $page.${uielem}btn -text $label \
+        ttk::label $page.$uielem -text $label
+        button $page.${uielem}btn -padx 40 -pady 0 -borderwidth 2 \
             -command [list choosecolor $colorvar $idx $page $title]
-        grid x $page.${uielem}btn $page.$uielem -sticky w
+        grid x $page.$uielem $page.${uielem}btn -sticky w -pady 1
     }
 
     grid columnconfigure $page 2 -weight 1
@@ -11896,7 +11896,7 @@ proc prefspage_set_colorswatches {page} {
         linkfg    $linkfgcolor \
     ]
     foreach {uielem color} $coloruielems {
-        $page.$uielem configure -background $color
+        $page.${uielem}btn configure -background $color -activebackground $color
     }
 }
 

--- a/gitk
+++ b/gitk
@@ -11801,8 +11801,6 @@ proc prefspage_general {notebook} {
 }
 
 proc prefspage_colors {notebook} {
-    global bgcolor fgcolor ctext diffcolors selectbgcolor markbgcolor
-    global diffbgcolors linkfgcolor
     global themeloader
 
     set page [create_prefs_page $notebook.colors]
@@ -11834,63 +11832,64 @@ proc prefspage_colors {notebook} {
 
     ttk::label $page.cdisp -text [mc "Colors: press to choose"] -font mainfontbold
     grid $page.cdisp - -sticky w -pady 10
-    label $page.bg -padx 40 -relief sunk -background $bgcolor
+    label $page.bg -padx 40 -relief sunk
     ttk::button $page.bgbut -text [mc "Background"] \
         -command [list choosecolor bgcolor {} $page [mc "background"]]
     grid x $page.bgbut $page.bg -sticky w
 
-    label $page.fg -padx 40 -relief sunk -background $fgcolor
+    label $page.fg -padx 40 -relief sunk
     ttk::button $page.fgbut -text [mc "Foreground"] \
         -command [list choosecolor fgcolor {} $page [mc "foreground"]]
     grid x $page.fgbut $page.fg -sticky w
 
-    label $page.diffold -padx 40 -relief sunk -background [lindex $diffcolors 0]
+    label $page.diffold -padx 40 -relief sunk
     ttk::button $page.diffoldbut -text [mc "Diff: old lines"] \
         -command [list choosecolor diffcolors 0 $page [mc "diff old lines"]]
     grid x $page.diffoldbut $page.diffold -sticky w
 
-    label $page.diffoldbg -padx 40 -relief sunk -background [lindex $diffbgcolors 0]
+    label $page.diffoldbg -padx 40 -relief sunk
     ttk::button $page.diffoldbgbut -text [mc "Diff: old lines bg"] \
         -command [list choosecolor diffbgcolors 0 $page [mc "diff old lines bg"]]
     grid x $page.diffoldbgbut $page.diffoldbg -sticky w
 
-    label $page.diffnew -padx 40 -relief sunk -background [lindex $diffcolors 1]
+    label $page.diffnew -padx 40 -relief sunk
     ttk::button $page.diffnewbut -text [mc "Diff: new lines"] \
         -command [list choosecolor diffcolors 1 $page [mc "diff new lines"]]
     grid x $page.diffnewbut $page.diffnew -sticky w
 
-    label $page.diffnewbg -padx 40 -relief sunk -background [lindex $diffbgcolors 1]
+    label $page.diffnewbg -padx 40 -relief sunk
     ttk::button $page.diffnewbgbut -text [mc "Diff: new lines bg"] \
         -command [list choosecolor diffbgcolors 1 $page [mc "diff new lines bg"]]
     grid x $page.diffnewbgbut $page.diffnewbg -sticky w
 
-    label $page.hunksep -padx 40 -relief sunk -background [lindex $diffcolors 2]
+    label $page.hunksep -padx 40 -relief sunk
     ttk::button $page.hunksepbut -text [mc "Diff: hunk header"] \
         -command [list choosecolor diffcolors 2 $page [mc "diff hunk header"]]
     grid x $page.hunksepbut $page.hunksep -sticky w
 
-    label $page.markbgsep -padx 40 -relief sunk -background $markbgcolor
+    label $page.markbgsep -padx 40 -relief sunk
     ttk::button $page.markbgbut -text [mc "Marked line bg"] \
         -command [list choosecolor markbgcolor {} $page [mc "marked line background"]]
     grid x $page.markbgbut $page.markbgsep -sticky w
 
-    label $page.selbgsep -padx 40 -relief sunk -background $selectbgcolor
+    label $page.selbgsep -padx 40 -relief sunk
     ttk::button $page.selbgbut -text [mc "Select bg"] \
         -command [list choosecolor selectbgcolor {} $page [mc "background"]]
     grid x $page.selbgbut $page.selbgsep -sticky w
 
-    label $page.linkfg -padx 40 -relief sunk -background $linkfgcolor
+    label $page.linkfg -padx 40 -relief sunk
     ttk::button $page.linkfgbut -text [mc "Link"] \
         -command [list choosecolor linkfgcolor {} $page [mc "link"]]
     grid x $page.linkfgbut $page.linkfg -sticky w
 
     grid columnconfigure $page 2 -weight 1
+    prefspage_set_colorswatches $page
 
     return $page
 }
 
 proc prefspage_set_colorswatches {page} {
-    global bgcolor fgcolor ctext diffcolors selectbgcolor markbgcolor
+    global bgcolor fgcolor diffcolors selectbgcolor markbgcolor
     global diffbgcolors linkfgcolor
 
     $page.bg configure -background $bgcolor


### PR DESCRIPTION
I find the user interface to set the color preferences a bit ugly for these reasons:

- The color samples are not clickable as one would expect who enters the dialog. Instead, the description is the button that must be clicked.

- Since the descriptive texts are different for the preferences, the width of the buttons are different, too.

- The descriptions themselves are not always natural language (read: they are nerdy) and use abbreviations.

This series makes the descriptions static text and turns the color samples into the clickable buttons. It also makes the descriptions and dialog titles more natural language.

This is the dialog before the change:
<img width="598" height="643" alt="Screenshot_color_buttons_before" src="https://github.com/user-attachments/assets/910a647f-4e56-47b0-b4c4-e6e7bc966e9c" />
And this is the dialog after the change:
<img width="598" height="643" alt="Screenshot_color_buttons_after" src="https://github.com/user-attachments/assets/d985d837-1b1e-4b43-8bcd-76bca8d060ce" />
